### PR TITLE
fix: add Suspense boundaries and Vercel deploy config to examples

### DIFF
--- a/examples/balance-fixed/app/(auth)/sign-in/page.tsx
+++ b/examples/balance-fixed/app/(auth)/sign-in/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -16,7 +16,7 @@ import { Label } from "@/components/ui/label";
 import { signIn } from "@/lib/auth/auth-client";
 import { handlePostSignupCheckout } from "@/lib/payments/actions";
 
-export default function SignInPage() {
+function SignInContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const redirect = searchParams.get("redirect") || "/dashboard";
@@ -104,5 +104,13 @@ export default function SignInPage() {
         </form>
       </CardContent>
     </Card>
+  );
+}
+
+export default function SignInPage() {
+  return (
+    <Suspense>
+      <SignInContent />
+    </Suspense>
   );
 }

--- a/examples/balance-fixed/app/(auth)/sign-up/page.tsx
+++ b/examples/balance-fixed/app/(auth)/sign-up/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -16,7 +16,7 @@ import { Label } from "@/components/ui/label";
 import { signUp } from "@/lib/auth/auth-client";
 import { handlePostSignupCheckout } from "@/lib/payments/actions";
 
-export default function SignUpPage() {
+function SignUpContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const redirect = searchParams.get("redirect") || "/dashboard";
@@ -115,5 +115,13 @@ export default function SignUpPage() {
         </form>
       </CardContent>
     </Card>
+  );
+}
+
+export default function SignUpPage() {
+  return (
+    <Suspense>
+      <SignUpContent />
+    </Suspense>
   );
 }

--- a/examples/balance-fixed/package.json
+++ b/examples/balance-fixed/package.json
@@ -36,6 +36,7 @@
     "tailwind-merge": "3.5.0",
     "zod": "4.3.6"
   },
+  "packageManager": "pnpm@10.28.0",
   "devDependencies": {
     "@tailwindcss/postcss": "4.2.1",
     "@types/node": "25.3.2",

--- a/examples/balance-fixed/pnpm-workspace.yaml
+++ b/examples/balance-fixed/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/examples/credits/app/(auth)/sign-in/page.tsx
+++ b/examples/credits/app/(auth)/sign-in/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -16,7 +16,7 @@ import { Label } from "@/components/ui/label";
 import { signIn } from "@/lib/auth/auth-client";
 import { handlePostSignupCheckout } from "@/lib/payments/actions";
 
-export default function SignInPage() {
+function SignInContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const redirect = searchParams.get("redirect") || "/dashboard";
@@ -104,5 +104,13 @@ export default function SignInPage() {
         </form>
       </CardContent>
     </Card>
+  );
+}
+
+export default function SignInPage() {
+  return (
+    <Suspense>
+      <SignInContent />
+    </Suspense>
   );
 }

--- a/examples/credits/app/(auth)/sign-up/page.tsx
+++ b/examples/credits/app/(auth)/sign-up/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -16,7 +16,7 @@ import { Label } from "@/components/ui/label";
 import { signUp } from "@/lib/auth/auth-client";
 import { handlePostSignupCheckout } from "@/lib/payments/actions";
 
-export default function SignUpPage() {
+function SignUpContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const redirect = searchParams.get("redirect") || "/dashboard";
@@ -115,5 +115,13 @@ export default function SignUpPage() {
         </form>
       </CardContent>
     </Card>
+  );
+}
+
+export default function SignUpPage() {
+  return (
+    <Suspense>
+      <SignUpContent />
+    </Suspense>
   );
 }

--- a/examples/credits/package.json
+++ b/examples/credits/package.json
@@ -36,6 +36,7 @@
     "tailwind-merge": "3.5.0",
     "zod": "4.3.6"
   },
+  "packageManager": "pnpm@10.28.0",
   "devDependencies": {
     "@tailwindcss/postcss": "4.2.1",
     "@types/node": "25.3.2",

--- a/examples/credits/pnpm-workspace.yaml
+++ b/examples/credits/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/examples/metered/app/(auth)/sign-in/page.tsx
+++ b/examples/metered/app/(auth)/sign-in/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -16,7 +16,7 @@ import { Label } from "@/components/ui/label";
 import { signIn } from "@/lib/auth/auth-client";
 import { handlePostSignupCheckout } from "@/lib/payments/actions";
 
-export default function SignInPage() {
+function SignInContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const redirect = searchParams.get("redirect") || "/dashboard";
@@ -104,5 +104,13 @@ export default function SignInPage() {
         </form>
       </CardContent>
     </Card>
+  );
+}
+
+export default function SignInPage() {
+  return (
+    <Suspense>
+      <SignInContent />
+    </Suspense>
   );
 }

--- a/examples/metered/app/(auth)/sign-up/page.tsx
+++ b/examples/metered/app/(auth)/sign-up/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -16,7 +16,7 @@ import { Label } from "@/components/ui/label";
 import { signUp } from "@/lib/auth/auth-client";
 import { handlePostSignupCheckout } from "@/lib/payments/actions";
 
-export default function SignUpPage() {
+function SignUpContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const redirect = searchParams.get("redirect") || "/dashboard";
@@ -115,5 +115,13 @@ export default function SignUpPage() {
         </form>
       </CardContent>
     </Card>
+  );
+}
+
+export default function SignUpPage() {
+  return (
+    <Suspense>
+      <SignUpContent />
+    </Suspense>
   );
 }

--- a/examples/metered/package.json
+++ b/examples/metered/package.json
@@ -35,6 +35,7 @@
     "tailwind-merge": "3.5.0",
     "zod": "4.3.6"
   },
+  "packageManager": "pnpm@10.28.0",
   "devDependencies": {
     "@tailwindcss/postcss": "4.2.1",
     "@types/node": "25.3.2",

--- a/examples/metered/pnpm-workspace.yaml
+++ b/examples/metered/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/examples/seats/app/(auth)/sign-in/page.tsx
+++ b/examples/seats/app/(auth)/sign-in/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -16,7 +16,7 @@ import { Label } from "@/components/ui/label";
 import { signIn } from "@/lib/auth/auth-client";
 import { handlePostSignupCheckout } from "@/lib/payments/actions";
 
-export default function SignInPage() {
+function SignInContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const redirect = searchParams.get("redirect") || "/dashboard";
@@ -104,5 +104,13 @@ export default function SignInPage() {
         </form>
       </CardContent>
     </Card>
+  );
+}
+
+export default function SignInPage() {
+  return (
+    <Suspense>
+      <SignInContent />
+    </Suspense>
   );
 }

--- a/examples/seats/app/(auth)/sign-up/page.tsx
+++ b/examples/seats/app/(auth)/sign-up/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -16,7 +16,7 @@ import { Label } from "@/components/ui/label";
 import { signUp } from "@/lib/auth/auth-client";
 import { handlePostSignupCheckout } from "@/lib/payments/actions";
 
-export default function SignUpPage() {
+function SignUpContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const redirect = searchParams.get("redirect") || "/dashboard";
@@ -115,5 +115,13 @@ export default function SignUpPage() {
         </form>
       </CardContent>
     </Card>
+  );
+}
+
+export default function SignUpPage() {
+  return (
+    <Suspense>
+      <SignUpContent />
+    </Suspense>
   );
 }

--- a/examples/seats/package.json
+++ b/examples/seats/package.json
@@ -35,6 +35,7 @@
     "tailwind-merge": "3.5.0",
     "zod": "4.3.6"
   },
+  "packageManager": "pnpm@10.28.0",
   "devDependencies": {
     "@tailwindcss/postcss": "4.2.1",
     "@types/node": "25.3.2",

--- a/examples/seats/pnpm-workspace.yaml
+++ b/examples/seats/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+packages: []


### PR DESCRIPTION
Wrap useSearchParams() in Suspense boundaries for sign-in and sign-up pages across balance-fixed, credits, metered, and seats examples. Add pnpm-workspace.yaml and packageManager field for Vercel deployment.