### PR TITLE
feat(node): expose consumptionModel + credits/balance on ActiveSubscription

### DIFF
--- a/.changeset/expose-consumption-model.md
+++ b/.changeset/expose-consumption-model.md
@@ -1,0 +1,5 @@
+---
+"@commet/node": minor
+---
+
+Add `consumptionModel`, `credits`, and `balance` fields to `ActiveSubscription` response from `subscriptions.get()`. Clients can now read credits or balance state for credits/balance plans instead of inferring it. `consumptionModel` is `"metered" | "credits" | "balance"` and indicates which summary (if any) is populated.

--- a/packages/node/src/resources/subscriptions.ts
+++ b/packages/node/src/resources/subscriptions.ts
@@ -55,7 +55,7 @@ export interface ActiveSubscription {
   name: string;
   description: string | null;
   status: SubscriptionStatus;
-  consumptionModel: ConsumptionModel;
+  consumptionModel: ConsumptionModel | null;
   trialEndsAt: string | null;
   currentPeriod: {
     start: string;

--- a/packages/node/src/resources/subscriptions.ts
+++ b/packages/node/src/resources/subscriptions.ts
@@ -29,6 +29,20 @@ export interface FeatureSummary {
   };
 }
 
+export interface CreditsSummary {
+  remaining: number;
+  included: number;
+  purchased: number;
+}
+
+export interface BalanceSummary {
+  remaining: number;
+  included: number;
+  currency: string;
+}
+
+export type ConsumptionModel = "metered" | "credits" | "balance";
+
 export interface ActiveSubscription {
   id: string;
   customerId: string;
@@ -41,6 +55,7 @@ export interface ActiveSubscription {
   name: string;
   description: string | null;
   status: SubscriptionStatus;
+  consumptionModel: ConsumptionModel;
   trialEndsAt: string | null;
   currentPeriod: {
     start: string;
@@ -48,6 +63,8 @@ export interface ActiveSubscription {
     daysRemaining: number;
   };
   features: FeatureSummary[];
+  credits: CreditsSummary | null;
+  balance: BalanceSummary | null;
   startDate: string;
   endDate: string | null;
   billingDayOfMonth: number;


### PR DESCRIPTION
## Summary

- Add `consumptionModel` (`"metered" | "credits" | "balance"`), `credits`, and `balance` fields to the `ActiveSubscription` response from `subscriptions.get()`.
- Clients can now read credits or balance state on credits/balance plans without casting to `any` or inferring from plan metadata.

## Impact

- Fully additive. No breaking changes — existing code keeps compiling.
- Pairs with platform PR #640 which exposes the new fields server-side.

## Test plan

- [x] `pnpm --filter=@commet/node typecheck`
- [ ] After publish, verify consuming app sees typed `credits.remaining` and `balance.remaining`