### PR TITLE
refactor: rename feature type metered → usage in SDK

### DIFF
--- a/.changeset/rename-feature-type-metered-to-usage.md
+++ b/.changeset/rename-feature-type-metered-to-usage.md
@@ -1,0 +1,9 @@
+---
+"@commet/node": minor
+"@commet/next": patch
+"commet": patch
+---
+
+Rename feature type enum value from `metered` to `usage` to disambiguate from the plan consumption model.
+
+Feature types are now `boolean | usage | seats`. The consumption model `metered` is unchanged.

--- a/examples/balance-fixed/app/pricing/page.tsx
+++ b/examples/balance-fixed/app/pricing/page.tsx
@@ -31,7 +31,7 @@ function formatFeature(feature: PlanFeature): string {
   if (feature.type === "boolean" && feature.enabled) {
     return feature.name;
   }
-  if (feature.type === "metered" && feature.includedAmount !== undefined) {
+  if (feature.type === "usage" && feature.includedAmount !== undefined) {
     return `${feature.includedAmount.toLocaleString()} ${feature.name} included`;
   }
   if (feature.type === "seats" && feature.includedAmount !== undefined) {

--- a/examples/credits/app/pricing/page.tsx
+++ b/examples/credits/app/pricing/page.tsx
@@ -31,7 +31,7 @@ function formatFeature(feature: PlanFeature): string {
   if (feature.type === "boolean" && feature.enabled) {
     return feature.name;
   }
-  if (feature.type === "metered" && feature.includedAmount !== undefined) {
+  if (feature.type === "usage" && feature.includedAmount !== undefined) {
     return `${feature.includedAmount.toLocaleString()} ${feature.name} included`;
   }
   if (feature.type === "seats" && feature.includedAmount !== undefined) {

--- a/examples/fixed/app/pricing/page.tsx
+++ b/examples/fixed/app/pricing/page.tsx
@@ -31,7 +31,7 @@ function formatFeature(feature: PlanFeature): string {
   if (feature.type === "boolean" && feature.enabled) {
     return feature.name;
   }
-  if (feature.type === "metered" && feature.includedAmount !== undefined) {
+  if (feature.type === "usage" && feature.includedAmount !== undefined) {
     return `${feature.includedAmount.toLocaleString()} ${feature.name} included`;
   }
   if (feature.type === "seats" && feature.includedAmount !== undefined) {

--- a/examples/metered/app/pricing/page.tsx
+++ b/examples/metered/app/pricing/page.tsx
@@ -31,7 +31,7 @@ function formatFeature(feature: PlanFeature): string {
   if (feature.type === "boolean" && feature.enabled) {
     return feature.name;
   }
-  if (feature.type === "metered" && feature.includedAmount !== undefined) {
+  if (feature.type === "usage" && feature.includedAmount !== undefined) {
     return `${feature.includedAmount.toLocaleString()} ${feature.name} included`;
   }
   if (feature.type === "seats" && feature.includedAmount !== undefined) {

--- a/examples/seats/app/pricing/page.tsx
+++ b/examples/seats/app/pricing/page.tsx
@@ -31,7 +31,7 @@ function formatFeature(feature: PlanFeature): string {
   if (feature.type === "boolean" && feature.enabled) {
     return feature.name;
   }
-  if (feature.type === "metered" && feature.includedAmount !== undefined) {
+  if (feature.type === "usage" && feature.includedAmount !== undefined) {
     return `${feature.includedAmount.toLocaleString()} ${feature.name} included`;
   }
   if (feature.type === "seats" && feature.includedAmount !== undefined) {

--- a/packages/next/src/pricing-markdown.ts
+++ b/packages/next/src/pricing-markdown.ts
@@ -293,7 +293,7 @@ function collectUsageFeatures(plans: Plan[]): UsageFeatureColumn[] {
   for (const plan of plans) {
     for (const feature of plan.features) {
       if (
-        (feature.type === "metered" || feature.type === "seats") &&
+        (feature.type === "usage" || feature.type === "seats") &&
         !seen.has(feature.code) &&
         hasUsageData(feature)
       ) {

--- a/packages/node/src/resources/features.ts
+++ b/packages/node/src/resources/features.ts
@@ -18,7 +18,7 @@ export type CanUseFeatureParams = FeatureParams;
 export interface FeatureAccess {
   code: string;
   name: string;
-  type: "boolean" | "metered" | "seats";
+  type: "boolean" | "usage" | "seats";
   allowed: boolean;
   enabled?: boolean;
   current?: number;

--- a/packages/node/src/resources/plans.ts
+++ b/packages/node/src/resources/plans.ts
@@ -12,7 +12,7 @@ export type BillingInterval =
   | "quarterly"
   | "yearly"
   | "one_time";
-export type FeatureType = "boolean" | "metered" | "seats";
+export type FeatureType = "boolean" | "usage" | "seats";
 
 export interface PlanPrice {
   billingInterval: BillingInterval;

--- a/packages/node/src/resources/subscriptions.ts
+++ b/packages/node/src/resources/subscriptions.ts
@@ -19,7 +19,7 @@ export type SubscriptionStatus =
 export interface FeatureSummary {
   code: string;
   name: string;
-  type: "boolean" | "metered" | "seats";
+  type: "boolean" | "usage" | "seats";
   enabled?: boolean;
   usage?: {
     current: number;

--- a/packages/node/src/version.ts
+++ b/packages/node/src/version.ts
@@ -1,4 +1,4 @@
-export const API_VERSION = "2026-05-12";
+export const API_VERSION = "2026-05-18";
 
 declare const __SDK_VERSION__: string;
 export const SDK_VERSION: string = __SDK_VERSION__;


### PR DESCRIPTION
## Summary

- Updates `FeatureType` union from `"boolean" | "metered" | "seats"` to `"boolean" | "usage" | "seats"` across `@commet/node`, `@commet/next`, and all examples
- Bumps `API_VERSION` to `2026-05-18`
- Changeset: `@commet/node` minor, `@commet/next` patch, `commet` patch

## What changed

- **@commet/node**: `FeatureType`, `FeatureAccess.type`, `FeatureSummary.type` updated
- **@commet/next**: `pricing-markdown.ts` feature type check updated
- **Examples**: all 5 pricing pages updated (`metered` → `usage` in feature type checks)
- **Version**: `API_VERSION` pinned to `2026-05-18`

## Backward compatibility

Old SDK versions continue to work — they pin `Commet-Version: 2026-05-12` and the platform's versioning pipeline transforms `type: "usage"` back to `"metered"` in responses.

## Test plan

- [x] SDK build: 5/5 packages pass
- [x] Biome: clean
- [x] Platform E2E backward compat tests verify old version header returns `"metered"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)