### PR TITLE
feat(node): webhook type fixes + per-endpoint API versioning

### DIFF
--- a/.changeset/fix-webhook-types.md
+++ b/.changeset/fix-webhook-types.md
@@ -1,0 +1,10 @@
+---
+"@commet/node": patch
+---
+
+Align webhook types with the actual API response shape:
+
+- `WebhookEndpoint.object` is now `"webhook"` (was incorrectly typed as `"webhook_endpoint"`, so equality checks never matched the real payload).
+- `WebhookPayload` now includes `mode` (`"live" | "sandbox"`) and `apiVersion`, which Commet always sends on delivered events.
+- `WebhookTestResult` now includes `deliveryId`, returned by the test endpoint so you can trace the delivery.
+- Removed the phantom `WebhookData.id` field that the API never returns — use `subscriptionId` / `customerId` instead.

--- a/.changeset/fix-webhook-types.md
+++ b/.changeset/fix-webhook-types.md
@@ -1,10 +1,13 @@
 ---
-"@commet/node": patch
+"@commet/node": minor
 ---
 
-Align webhook types with the actual API response shape:
+Webhook types and per-endpoint API versioning:
 
 - `WebhookEndpoint.object` is now `"webhook"` (was incorrectly typed as `"webhook_endpoint"`, so equality checks never matched the real payload).
 - `WebhookPayload` now includes `mode` (`"live" | "sandbox"`) and `apiVersion`, which Commet always sends on delivered events.
 - `WebhookTestResult` now includes `deliveryId`, returned by the test endpoint so you can trace the delivery.
 - Removed the phantom `WebhookData.id` field that the API never returns — use `subscriptionId` / `customerId` instead.
+- `webhooks.create` accepts an optional `apiVersion` to pin the endpoint to a specific API version. When omitted, the endpoint inherits the version of the request that creates it (i.e. the SDK's version), so the payloads you receive match the types you parse with.
+- `WebhookEndpoint` now exposes `apiVersion` (the version the endpoint is pinned to).
+- Added `webhooks.update(...)` for the new `PUT /webhooks/{id}` endpoint.

--- a/.changeset/webhooks-cli-get-update.md
+++ b/.changeset/webhooks-cli-get-update.md
@@ -1,0 +1,5 @@
+---
+"commet": patch
+---
+
+Add `webhooks get` and `webhooks update` commands, and a `--api-version` flag to `webhooks create` to pin an endpoint to an API version.

--- a/.changeset/webhooks-get.md
+++ b/.changeset/webhooks-get.md
@@ -1,0 +1,5 @@
+---
+"@commet/node": patch
+---
+
+Add `webhooks.get(...)` to retrieve a single webhook endpoint via `GET /webhooks/{id}`.

--- a/packages/cli/src/commands/resources/registry.ts
+++ b/packages/cli/src/commands/resources/registry.ts
@@ -1731,6 +1731,63 @@ const webhooksResource: ResourceDef = {
           description: "Webhook description",
           sdkKey: "description",
         },
+        {
+          flag: "--api-version <version>",
+          description: "Pin the endpoint to an API version",
+          sdkKey: "apiVersion",
+        },
+      ],
+    },
+    get: {
+      method: "get",
+      description: "Get a webhook endpoint",
+      params: [
+        {
+          flag: "--id <id>",
+          description: "Webhook endpoint ID",
+          required: true,
+          sdkKey: "id",
+        },
+      ],
+    },
+    update: {
+      method: "update",
+      description: "Update a webhook endpoint",
+      params: [
+        {
+          flag: "--id <id>",
+          description: "Webhook endpoint ID",
+          required: true,
+          sdkKey: "id",
+        },
+        {
+          flag: "--url <url>",
+          description: "Webhook URL",
+          sdkKey: "url",
+        },
+        {
+          flag: "--events <json>",
+          description:
+            'Events to subscribe to (JSON array: ["subscription.created"])',
+          parse: parseJson,
+          sdkKey: "events",
+        },
+        {
+          flag: "--description <desc>",
+          description: "Webhook description",
+          sdkKey: "description",
+        },
+        {
+          flag: "--is-active <bool>",
+          description: "Whether the endpoint is active",
+          parse: parseBool,
+          sdkKey: "isActive",
+        },
+        {
+          flag: "--api-version <version>",
+          description: "Pin the endpoint to an API version",
+          sdkKey: "apiVersion",
+        },
       ],
     },
     delete: {

--- a/packages/next/src/webhooks.test.ts
+++ b/packages/next/src/webhooks.test.ts
@@ -5,23 +5,26 @@ import { Webhooks } from "./webhooks";
 
 // Mock @commet/node
 vi.mock("@commet/node", () => ({
-  Webhooks: vi.fn().mockImplementation(() => ({
-    verify: vi.fn().mockReturnValue(true),
-  })),
+  Webhooks: vi.fn(),
 }));
 
 const mockCommetWebhooks = vi.mocked(CommetWebhooks);
+
+// Must stay a real function (not an arrow) so vitest can call it with `new CommetWebhooks()`.
+function webhooksMock(verifyResult: boolean) {
+  // biome-ignore lint/complexity/useArrowFunction: a constructable function is required here
+  return function () {
+    return {
+      verify: vi.fn().mockReturnValue(verifyResult),
+    } as unknown as InstanceType<typeof CommetWebhooks>;
+  };
+}
 
 describe("Webhooks", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Reset the mock to return true by default
-    mockCommetWebhooks.mockImplementation(
-      () =>
-        ({
-          verify: vi.fn().mockReturnValue(true),
-        }) as unknown as InstanceType<typeof CommetWebhooks>,
-    );
+    mockCommetWebhooks.mockImplementation(webhooksMock(true));
   });
 
   describe("signature verification", () => {
@@ -61,12 +64,7 @@ describe("Webhooks", () => {
 
     it("should return 403 for invalid signatures", async () => {
       // Mock verify to return false
-      mockCommetWebhooks.mockImplementation(
-        () =>
-          ({
-            verify: vi.fn().mockReturnValue(false),
-          }) as unknown as InstanceType<typeof CommetWebhooks>,
-      );
+      mockCommetWebhooks.mockImplementation(webhooksMock(false));
 
       const mockHandler = vi.fn();
       const webhookHandler = Webhooks({
@@ -96,12 +94,7 @@ describe("Webhooks", () => {
 
     it("should handle missing signature header", async () => {
       // Mock verify to return false for null signature
-      mockCommetWebhooks.mockImplementation(
-        () =>
-          ({
-            verify: vi.fn().mockReturnValue(false),
-          }) as unknown as InstanceType<typeof CommetWebhooks>,
-      );
+      mockCommetWebhooks.mockImplementation(webhooksMock(false));
 
       const webhookHandler = Webhooks({
         webhookSecret: "secret_123",

--- a/packages/node/src/__tests__/http.test.ts
+++ b/packages/node/src/__tests__/http.test.ts
@@ -29,7 +29,7 @@ describe("CommetHTTPClient", () => {
   });
 
   describe("URL building", () => {
-    it("builds URL with /api prefix", async () => {
+    it("builds URL with /api/v1 prefix", async () => {
       const client = createClient();
       vi.mocked(fetch).mockResolvedValueOnce(
         jsonResponse({ success: true, data: {} }),
@@ -38,7 +38,7 @@ describe("CommetHTTPClient", () => {
       await client.get("/customers");
 
       expect(fetch).toHaveBeenCalledWith(
-        "https://commet.co/api/customers",
+        "https://commet.co/api/v1/customers",
         expect.any(Object),
       );
     });
@@ -83,7 +83,7 @@ describe("CommetHTTPClient", () => {
       await client.get("customers");
 
       expect(fetch).toHaveBeenCalledWith(
-        "https://commet.co/api/customers",
+        "https://commet.co/api/v1/customers",
         expect.any(Object),
       );
     });
@@ -122,7 +122,7 @@ describe("CommetHTTPClient", () => {
 
       const requestInit = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
       const headers = requestInit.headers as Record<string, string>;
-      expect(headers["Idempotency-Key"]).toMatch(/^sdk_/);
+      expect(headers["Idempotency-Key"]).toMatch(/^commet-node-retry-/);
     });
   });
 
@@ -130,7 +130,10 @@ describe("CommetHTTPClient", () => {
     it("throws CommetAPIError on 4xx response", async () => {
       const client = createClient({ retries: 0 });
       vi.mocked(fetch).mockResolvedValueOnce(
-        jsonResponse({ message: "Customer not found", code: "not_found" }, 404),
+        jsonResponse(
+          { error: { message: "Customer not found", code: "not_found" } },
+          404,
+        ),
       );
 
       await expect(client.get("/customers/missing")).rejects.toThrow(
@@ -147,7 +150,10 @@ describe("CommetHTTPClient", () => {
     it("includes statusCode and code on API error", async () => {
       const client = createClient({ retries: 0 });
       vi.mocked(fetch).mockResolvedValueOnce(
-        jsonResponse({ message: "Forbidden", code: "forbidden" }, 403),
+        jsonResponse(
+          { error: { message: "Forbidden", code: "forbidden" } },
+          403,
+        ),
       );
 
       try {
@@ -167,13 +173,15 @@ describe("CommetHTTPClient", () => {
       vi.mocked(fetch).mockResolvedValueOnce(
         jsonResponse(
           {
-            message: "Validation failed",
-            code: "validation_error",
-            details: [
-              { field: "email", message: "is required" },
-              { field: "email", message: "must be valid" },
-              { field: "name", message: "is too short" },
-            ],
+            error: {
+              message: "Validation failed",
+              code: "validation_error",
+              details: [
+                { field: "email", message: "is required" },
+                { field: "email", message: "must be valid" },
+                { field: "name", message: "is too short" },
+              ],
+            },
           },
           422,
         ),

--- a/packages/node/src/__tests__/webhooks.test.ts
+++ b/packages/node/src/__tests__/webhooks.test.ts
@@ -14,7 +14,7 @@ describe("Webhooks", () => {
     timestamp: "2026-04-11T12:00:00Z",
     organizationId: "org_123",
     data: {
-      id: "sub_abc",
+      subscriptionId: "sub_abc",
       customerId: "cus_456",
       status: "active",
     },

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -181,6 +181,7 @@ export type {
 export type {
   CreateWebhookParams,
   DeleteWebhookParams,
+  GetWebhookParams,
   ListWebhooksParams,
   TestWebhookParams,
   UpdateWebhookParams,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -183,6 +183,7 @@ export type {
   DeleteWebhookParams,
   ListWebhooksParams,
   TestWebhookParams,
+  UpdateWebhookParams,
   WebhookData,
   WebhookEndpoint,
   WebhookEndpointCreated,

--- a/packages/node/src/resources/webhooks.ts
+++ b/packages/node/src/resources/webhooks.ts
@@ -75,6 +75,8 @@ export interface WebhookEndpoint {
   events: string[];
   description: string | null;
   isActive: boolean;
+  /** API version this endpoint is pinned to. `null` means it inherits the account version. */
+  apiVersion: string | null;
   createdAt: string;
 }
 
@@ -97,6 +99,17 @@ export interface CreateWebhookParams {
   url: string;
   events: string[];
   description?: string;
+  /** Pin this endpoint to an API version. Defaults to the version of the request that creates it. */
+  apiVersion?: string;
+}
+
+export interface UpdateWebhookParams {
+  id: string;
+  url?: string;
+  events?: string[];
+  description?: string | null;
+  isActive?: boolean;
+  apiVersion?: string;
 }
 
 export interface DeleteWebhookParams {
@@ -165,6 +178,15 @@ export class Webhooks {
     options?: RequestOptions,
   ): Promise<ApiResponse<WebhookEndpointCreated>> {
     return this.httpClient!.post("/webhooks", params, options);
+  }
+
+  /** Update an existing webhook endpoint. Only the provided fields change. */
+  async update(
+    params: UpdateWebhookParams,
+    options?: RequestOptions,
+  ): Promise<ApiResponse<WebhookEndpoint>> {
+    const { id, ...body } = params;
+    return this.httpClient!.put(`/webhooks/${id}`, body, options);
   }
 
   async delete(

--- a/packages/node/src/resources/webhooks.ts
+++ b/packages/node/src/resources/webhooks.ts
@@ -75,7 +75,6 @@ export interface WebhookEndpoint {
   events: string[];
   description: string | null;
   isActive: boolean;
-  /** API version this endpoint is pinned to. `null` means it inherits the account version. */
   apiVersion: string | null;
   createdAt: string;
 }
@@ -99,7 +98,6 @@ export interface CreateWebhookParams {
   url: string;
   events: string[];
   description?: string;
-  /** Pin this endpoint to an API version. Defaults to the version of the request that creates it. */
   apiVersion?: string;
 }
 
@@ -176,7 +174,6 @@ export class Webhooks {
     return this.httpClient!.get("/webhooks", params, options);
   }
 
-  /** Response includes `secretKey` which is only returned once. */
   async create(
     params: CreateWebhookParams,
     options?: RequestOptions,
@@ -192,7 +189,6 @@ export class Webhooks {
     return this.httpClient!.get(`/webhooks/${id}`, undefined, options);
   }
 
-  /** Update an existing webhook endpoint. Only the provided fields change. */
   async update(
     params: UpdateWebhookParams,
     options?: RequestOptions,

--- a/packages/node/src/resources/webhooks.ts
+++ b/packages/node/src/resources/webhooks.ts
@@ -10,6 +10,8 @@ export interface WebhookPayload {
   event: WebhookEvent;
   timestamp: string;
   organizationId: string;
+  mode: "live" | "sandbox";
+  apiVersion: string;
   data: WebhookData;
 }
 
@@ -22,7 +24,6 @@ export interface WebhookPayload {
  * granting access.
  */
 export interface WebhookData {
-  id?: string;
   publicId?: string;
   subscriptionId?: string;
   customerId?: string;
@@ -68,7 +69,7 @@ export interface VerifyAndParseParams {
 
 export interface WebhookEndpoint {
   id: string;
-  object: "webhook_endpoint";
+  object: "webhook";
   livemode: boolean;
   url: string;
   events: string[];
@@ -83,6 +84,7 @@ export interface WebhookEndpointCreated extends WebhookEndpoint {
 
 export interface WebhookTestResult {
   success: boolean;
+  deliveryId: string;
   deliveredAt: string;
 }
 

--- a/packages/node/src/resources/webhooks.ts
+++ b/packages/node/src/resources/webhooks.ts
@@ -103,6 +103,10 @@ export interface CreateWebhookParams {
   apiVersion?: string;
 }
 
+export interface GetWebhookParams {
+  id: string;
+}
+
 export interface UpdateWebhookParams {
   id: string;
   url?: string;
@@ -178,6 +182,14 @@ export class Webhooks {
     options?: RequestOptions,
   ): Promise<ApiResponse<WebhookEndpointCreated>> {
     return this.httpClient!.post("/webhooks", params, options);
+  }
+
+  async get(
+    params: GetWebhookParams,
+    options?: RequestOptions,
+  ): Promise<ApiResponse<WebhookEndpoint>> {
+    const { id } = params;
+    return this.httpClient!.get(`/webhooks/${id}`, undefined, options);
   }
 
   /** Update an existing webhook endpoint. Only the provided fields change. */

--- a/packages/node/vitest.config.ts
+++ b/packages/node/vitest.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
+import pkg from "./package.json";
 
 export default defineConfig({
+  define: {
+    __SDK_VERSION__: JSON.stringify(pkg.version),
+  },
   test: {
     globals: true,
     environment: "node",


### PR DESCRIPTION
## What

Aligns the webhook types in `@commet/node` with the real API, and adds per-endpoint API versioning.

### Type fixes
- `WebhookEndpoint.object` is now `"webhook"` (was `"webhook_endpoint"`, so equality checks never matched the real payload)
- `WebhookPayload` includes `mode` (`"live" | "sandbox"`) and `apiVersion`, which are always sent on delivered events
- `WebhookTestResult` includes `deliveryId`
- removed the phantom `WebhookData.id` (the API uses `subscriptionId` / `customerId`)

These propagate automatically to `@commet/next` and `@commet/better-auth`, which only re-export the types.

### Per-endpoint API versioning
- `webhooks.create({ apiVersion? })` pins the endpoint to an API version; when omitted it inherits the version of the request that creates it (the SDK's version), so the payloads you receive match the types you parse with
- `WebhookEndpoint` exposes `apiVersion`
- new `webhooks.update(...)` for `PUT /webhooks/{id}`

### Test infrastructure (pre-existing failures, now fixed)
- define `__SDK_VERSION__` in the vitest config so the client/http suites load (tsup injects it at build; vitest did not)
- update the http client tests to current SDK behavior (`/api/v1` prefix, `commet-node-retry` idempotency key, nested `{ error }` error shape)
- make the `@commet/node` mock a constructable function (vitest 4 rejects arrow-function mocks used with `new`)

Changeset: `@commet/node` minor.

## Test plan
- `pnpm --filter @commet/node typecheck` / `test` (53 passed) / `build` / `lint`
- `@commet/next` and `@commet/better-auth` typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
