### PR TITLE
feat: add quota resource to commet-node SDK (BIL-1348)

### DIFF
--- a/.changeset/quota-resource.md
+++ b/.changeset/quota-resource.md
@@ -2,4 +2,4 @@
 "@commet/node": minor
 ---
 
-Add `quota` resource for durable balance tracking (the `quota` feature type). `quota.add`, `quota.set` and `quota.remove` mutate the balance; `quota.get` and `quota.getAll` read the current allowance (units held vs included in the plan, remaining, and whether overage is enabled).
+Add `quota` resource for durable balance tracking (the `quota` feature type). `quota.add`, `quota.set` and `quota.remove` mutate the balance; `quota.get` and `quota.getAll` read the current allowance (units held vs included in the plan, remaining, and whether overage is enabled). `quota` is now a recognized `FeatureType`, so `features.get` and `features.list` return access (current, included, overage and overage price) for quota features too.

--- a/.changeset/quota-resource.md
+++ b/.changeset/quota-resource.md
@@ -1,0 +1,5 @@
+---
+"@commet/node": minor
+---
+
+Add `quota` resource for durable balance tracking (the `quota` feature type). `quota.add`, `quota.set` and `quota.remove` mutate the balance; `quota.get` and `quota.getAll` read the current allowance (units held vs included in the plan, remaining, and whether overage is enabled).

--- a/.changeset/quota-resource.md
+++ b/.changeset/quota-resource.md
@@ -3,3 +3,5 @@
 ---
 
 Add `quota` resource for durable balance tracking (the `quota` feature type). `quota.add`, `quota.set` and `quota.remove` mutate the balance; `quota.get` and `quota.getAll` read the current allowance (units held vs included in the plan, remaining, and whether overage is enabled). `quota` is now a recognized `FeatureType`, so `features.get` and `features.list` return access (current, included, overage and overage price) for quota features too.
+
+`QuotaAllowance` and `FeatureAccess` also expose `billedQuantity`: the period high-water-mark the customer is billed for (peak units reached, locked in until renewal even if usage drops). Use it instead of `current` to show the effective billed limit.

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -72,6 +72,19 @@ await commet.seats.add({
   count: 5
 });
 
+// Track durable quota (e.g. projects, tasks)
+await commet.quota.add({
+  customerId: 'cus_123',
+  featureCode: 'projects',
+  count: 5
+});
+
+// Read the current quota allowance (held vs included)
+const projects = await commet.quota.get({
+  customerId: 'cus_123',
+  featureCode: 'projects'
+});
+
 // Check feature access
 const feature = await commet.features.get({
   externalId: 'user_123',

--- a/packages/node/src/__tests__/quota.test.ts
+++ b/packages/node/src/__tests__/quota.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from "vitest";
+import { QuotaResource } from "../resources/quota";
+import { CommetAPIError } from "../types/common";
+import type { CommetHTTPClient } from "../utils/http";
+
+function createMockClient() {
+  return {
+    get: vi.fn().mockResolvedValue({ success: true, data: {} }),
+    post: vi.fn().mockResolvedValue({ success: true, data: {} }),
+    put: vi.fn().mockResolvedValue({ success: true, data: {} }),
+    delete: vi.fn().mockResolvedValue({ success: true, data: {} }),
+  };
+}
+
+function quotaResource(client: ReturnType<typeof createMockClient>) {
+  return new QuotaResource(client as unknown as CommetHTTPClient);
+}
+
+describe("QuotaResource", () => {
+  describe("add", () => {
+    it("posts to /usage/quota with count defaulting to 1", async () => {
+      const client = createMockClient();
+      await quotaResource(client).add({
+        customerId: "cus_1",
+        featureCode: "projects",
+      });
+
+      expect(client.post).toHaveBeenCalledWith(
+        "/usage/quota",
+        { customerId: "cus_1", featureCode: "projects", count: 1 },
+        undefined,
+      );
+    });
+
+    it("passes an explicit count and request options", async () => {
+      const client = createMockClient();
+      await quotaResource(client).add(
+        { customerId: "cus_1", featureCode: "projects", count: 5 },
+        { idempotencyKey: "idem_1" },
+      );
+
+      expect(client.post).toHaveBeenCalledWith(
+        "/usage/quota",
+        { customerId: "cus_1", featureCode: "projects", count: 5 },
+        { idempotencyKey: "idem_1" },
+      );
+    });
+  });
+
+  describe("set", () => {
+    it("puts the exact count to /usage/quota", async () => {
+      const client = createMockClient();
+      await quotaResource(client).set({
+        customerId: "cus_1",
+        featureCode: "projects",
+        count: 100,
+      });
+
+      expect(client.put).toHaveBeenCalledWith(
+        "/usage/quota",
+        { customerId: "cus_1", featureCode: "projects", count: 100 },
+        undefined,
+      );
+    });
+  });
+
+  describe("remove", () => {
+    it("deletes from /usage/quota with count defaulting to 1", async () => {
+      const client = createMockClient();
+      await quotaResource(client).remove({
+        customerId: "cus_1",
+        featureCode: "projects",
+      });
+
+      expect(client.delete).toHaveBeenCalledWith(
+        "/usage/quota",
+        { customerId: "cus_1", featureCode: "projects", count: 1 },
+        undefined,
+      );
+    });
+
+    it("propagates an insufficient_balance API error", async () => {
+      const client = createMockClient();
+      client.delete.mockRejectedValueOnce(
+        new CommetAPIError(
+          "Cannot decrement 9999 from quota. Current balance is 5",
+          400,
+          "insufficient_balance",
+        ),
+      );
+
+      await expect(
+        quotaResource(client).remove({
+          customerId: "cus_1",
+          featureCode: "projects",
+          count: 9999,
+        }),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        code: "insufficient_balance",
+      });
+    });
+  });
+
+  describe("get", () => {
+    it("gets the single allowance from /usage/quota", async () => {
+      const client = createMockClient();
+      const allowance = {
+        featureCode: "projects",
+        current: 5,
+        included: 100,
+        remaining: 95,
+        unlimited: false,
+        overageEnabled: true,
+        asOf: "2026-05-29T00:00:00.000Z",
+      };
+      client.get.mockResolvedValueOnce({ success: true, data: allowance });
+
+      const result = await quotaResource(client).get({
+        customerId: "cus_1",
+        featureCode: "projects",
+      });
+
+      expect(client.get).toHaveBeenCalledWith("/usage/quota", {
+        customerId: "cus_1",
+        featureCode: "projects",
+      });
+      expect(result.data).toEqual(allowance);
+    });
+  });
+
+  describe("getAll", () => {
+    it("returns the array of allowances from /usage/quota/all", async () => {
+      const client = createMockClient();
+      const allowances = [
+        {
+          featureCode: "projects",
+          current: 42,
+          included: 1000,
+          remaining: 958,
+          unlimited: false,
+          overageEnabled: true,
+          asOf: "2026-05-29T00:00:00.000Z",
+        },
+      ];
+      client.get.mockResolvedValueOnce({ success: true, data: allowances });
+
+      const result = await quotaResource(client).getAll({
+        customerId: "cus_1",
+      });
+
+      expect(client.get).toHaveBeenCalledWith("/usage/quota/all", {
+        customerId: "cus_1",
+      });
+      expect(result.data).toEqual(allowances);
+    });
+  });
+
+  describe("count boundary", () => {
+    it("treats an explicit count of 0 as 0, not the default", async () => {
+      const client = createMockClient();
+      await quotaResource(client).add({
+        customerId: "cus_1",
+        featureCode: "projects",
+        count: 0,
+      });
+      await quotaResource(client).remove({
+        customerId: "cus_1",
+        featureCode: "projects",
+        count: 0,
+      });
+
+      expect(client.post).toHaveBeenCalledWith(
+        "/usage/quota",
+        { customerId: "cus_1", featureCode: "projects", count: 0 },
+        undefined,
+      );
+      expect(client.delete).toHaveBeenCalledWith(
+        "/usage/quota",
+        { customerId: "cus_1", featureCode: "projects", count: 0 },
+        undefined,
+      );
+    });
+  });
+});

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -8,6 +8,7 @@ import { PlanGroupsResource } from "./resources/plan-groups";
 import { PlansResource } from "./resources/plans";
 import { PortalResource } from "./resources/portal";
 import { PromoCodesResource } from "./resources/promo-codes";
+import { QuotaResource } from "./resources/quota";
 import { SeatsResource } from "./resources/seats";
 import { SubscriptionsResource } from "./resources/subscriptions";
 import { TransactionsResource } from "./resources/transactions";
@@ -30,6 +31,7 @@ export class Commet<_TConfig = unknown> {
   public readonly plans: PlansResource;
   public readonly portal: PortalResource;
   public readonly promoCodes: PromoCodesResource;
+  public readonly quota: QuotaResource;
   public readonly seats: SeatsResource;
   public readonly subscriptions: SubscriptionsResource;
   public readonly transactions: TransactionsResource;
@@ -58,6 +60,7 @@ export class Commet<_TConfig = unknown> {
     this.plans = new PlansResource(this.httpClient);
     this.portal = new PortalResource(this.httpClient);
     this.promoCodes = new PromoCodesResource(this.httpClient);
+    this.quota = new QuotaResource(this.httpClient);
     this.seats = new SeatsResource(this.httpClient);
     this.subscriptions = new SubscriptionsResource(this.httpClient);
     this.transactions = new TransactionsResource(this.httpClient);

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -121,6 +121,15 @@ export type {
   UpdatePromoCodeParams,
 } from "./resources/promo-codes";
 export type {
+  AddQuotaParams,
+  GetAllQuotaParams,
+  GetQuotaParams,
+  QuotaAllowance,
+  QuotaEvent,
+  RemoveQuotaParams,
+  SetQuotaParams,
+} from "./resources/quota";
+export type {
   AddSeatsParams,
   GetAllBalancesParams,
   GetBalanceParams,

--- a/packages/node/src/resources/features.ts
+++ b/packages/node/src/resources/features.ts
@@ -1,5 +1,6 @@
 import type { ApiResponse, CustomerID, RequestOptions } from "../types/common";
 import type { CommetHTTPClient } from "../utils/http";
+import type { FeatureType } from "./plans";
 
 export interface GetFeatureParams {
   customerId: CustomerID;
@@ -20,7 +21,7 @@ export interface FeatureAccess {
   livemode: boolean;
   code: string;
   name: string;
-  type: "boolean" | "usage" | "seats";
+  type: FeatureType;
   allowed: boolean;
   enabled?: boolean;
   current?: number;
@@ -44,7 +45,7 @@ export interface Feature {
   livemode: boolean;
   name: string;
   code: string;
-  type: "boolean" | "usage" | "seats";
+  type: FeatureType;
   description: string | null;
   unitName: string | null;
   createdAt: string;
@@ -54,7 +55,7 @@ export interface Feature {
 export interface CreateFeatureParams {
   code: string;
   name: string;
-  type: "boolean" | "usage" | "seats";
+  type: FeatureType;
   description?: string;
   unitName?: string;
 }

--- a/packages/node/src/resources/features.ts
+++ b/packages/node/src/resources/features.ts
@@ -29,6 +29,7 @@ export interface FeatureAccess {
   remaining?: number;
   overage?: number;
   overageUnitPrice?: number;
+  billedQuantity?: number;
   unlimited?: boolean;
   overageEnabled?: boolean;
 }

--- a/packages/node/src/resources/plans.ts
+++ b/packages/node/src/resources/plans.ts
@@ -8,7 +8,7 @@ export type BillingInterval =
   | "quarterly"
   | "yearly"
   | "one_time";
-export type FeatureType = "boolean" | "usage" | "seats";
+export type FeatureType = "boolean" | "usage" | "seats" | "quota";
 
 export interface PlanPrice {
   billingInterval: BillingInterval;

--- a/packages/node/src/resources/quota.ts
+++ b/packages/node/src/resources/quota.ts
@@ -13,15 +13,11 @@ export interface QuotaEvent {
 
 export interface QuotaAllowance {
   featureCode: string;
-  /** Units currently held — the durable balance. */
   current: number;
-  /** Units included in the customer's plan. */
   included: number;
-  /** `included - current`, or `null` when the feature is unlimited. */
   remaining: number | null;
   unlimited: boolean;
   overageEnabled: boolean;
-  /** Timestamp of the latest balance change, or `null` if the balance was never set. */
   asOf: string | null;
 }
 
@@ -55,7 +51,6 @@ export interface GetAllQuotaParams {
 export class QuotaResource {
   constructor(private httpClient: CommetHTTPClient) {}
 
-  /** Increments the durable quota balance. Defaults to 1. */
   async add(
     params: AddQuotaParams,
     options?: RequestOptions,
@@ -71,7 +66,6 @@ export class QuotaResource {
     );
   }
 
-  /** Sets the durable quota balance to an exact value. */
   async set(
     params: SetQuotaParams,
     options?: RequestOptions,
@@ -87,11 +81,6 @@ export class QuotaResource {
     );
   }
 
-  /**
-   * Decrements the durable quota balance. Defaults to 1.
-   * Rejects with a `CommetAPIError` (`code: "insufficient_balance"`, status 400)
-   * if the balance would go negative.
-   */
   async remove(
     params: RemoveQuotaParams,
     options?: RequestOptions,
@@ -107,7 +96,6 @@ export class QuotaResource {
     );
   }
 
-  /** Returns the current allowance (held vs included) for a single quota feature. */
   async get(params: GetQuotaParams): Promise<ApiResponse<QuotaAllowance>> {
     return this.httpClient.get("/usage/quota", {
       customerId: params.customerId,
@@ -115,7 +103,6 @@ export class QuotaResource {
     });
   }
 
-  /** Returns the current allowance for every quota feature in the customer's plan. */
   async getAll(
     params: GetAllQuotaParams,
   ): Promise<ApiResponse<QuotaAllowance[]>> {

--- a/packages/node/src/resources/quota.ts
+++ b/packages/node/src/resources/quota.ts
@@ -1,0 +1,126 @@
+import type { ApiResponse, CustomerID, RequestOptions } from "../types/common";
+import type { CommetHTTPClient } from "../utils/http";
+
+export interface QuotaEvent {
+  id: string;
+  customerId: CustomerID;
+  featureCode: string;
+  previousBalance: number;
+  newBalance: number;
+  ts: string;
+  createdAt: string;
+}
+
+export interface QuotaAllowance {
+  featureCode: string;
+  /** Units currently held — the durable balance. */
+  current: number;
+  /** Units included in the customer's plan. */
+  included: number;
+  /** `included - current`, or `null` when the feature is unlimited. */
+  remaining: number | null;
+  unlimited: boolean;
+  overageEnabled: boolean;
+  /** Timestamp of the latest balance change, or `null` if the balance was never set. */
+  asOf: string | null;
+}
+
+export interface AddQuotaParams {
+  customerId: CustomerID;
+  featureCode: string;
+  count?: number;
+}
+
+export interface SetQuotaParams {
+  customerId: CustomerID;
+  featureCode: string;
+  count: number;
+}
+
+export interface RemoveQuotaParams {
+  customerId: CustomerID;
+  featureCode: string;
+  count?: number;
+}
+
+export interface GetQuotaParams {
+  customerId: CustomerID;
+  featureCode: string;
+}
+
+export interface GetAllQuotaParams {
+  customerId: CustomerID;
+}
+
+export class QuotaResource {
+  constructor(private httpClient: CommetHTTPClient) {}
+
+  /** Increments the durable quota balance. Defaults to 1. */
+  async add(
+    params: AddQuotaParams,
+    options?: RequestOptions,
+  ): Promise<ApiResponse<QuotaEvent>> {
+    return this.httpClient.post(
+      "/usage/quota",
+      {
+        customerId: params.customerId,
+        featureCode: params.featureCode,
+        count: params.count ?? 1,
+      },
+      options,
+    );
+  }
+
+  /** Sets the durable quota balance to an exact value. */
+  async set(
+    params: SetQuotaParams,
+    options?: RequestOptions,
+  ): Promise<ApiResponse<QuotaEvent>> {
+    return this.httpClient.put(
+      "/usage/quota",
+      {
+        customerId: params.customerId,
+        featureCode: params.featureCode,
+        count: params.count,
+      },
+      options,
+    );
+  }
+
+  /**
+   * Decrements the durable quota balance. Defaults to 1.
+   * Rejects with a `CommetAPIError` (`code: "insufficient_balance"`, status 400)
+   * if the balance would go negative.
+   */
+  async remove(
+    params: RemoveQuotaParams,
+    options?: RequestOptions,
+  ): Promise<ApiResponse<QuotaEvent>> {
+    return this.httpClient.delete(
+      "/usage/quota",
+      {
+        customerId: params.customerId,
+        featureCode: params.featureCode,
+        count: params.count ?? 1,
+      },
+      options,
+    );
+  }
+
+  /** Returns the current allowance (held vs included) for a single quota feature. */
+  async get(params: GetQuotaParams): Promise<ApiResponse<QuotaAllowance>> {
+    return this.httpClient.get("/usage/quota", {
+      customerId: params.customerId,
+      featureCode: params.featureCode,
+    });
+  }
+
+  /** Returns the current allowance for every quota feature in the customer's plan. */
+  async getAll(
+    params: GetAllQuotaParams,
+  ): Promise<ApiResponse<QuotaAllowance[]>> {
+    return this.httpClient.get("/usage/quota/all", {
+      customerId: params.customerId,
+    });
+  }
+}

--- a/packages/node/src/resources/quota.ts
+++ b/packages/node/src/resources/quota.ts
@@ -16,6 +16,7 @@ export interface QuotaAllowance {
   current: number;
   included: number;
   remaining: number | null;
+  billedQuantity?: number;
   unlimited: boolean;
   overageEnabled: boolean;
   asOf: string | null;

--- a/packages/node/src/resources/subscriptions.ts
+++ b/packages/node/src/resources/subscriptions.ts
@@ -1,6 +1,6 @@
 import type { ApiResponse, RequestOptions } from "../types/common";
 import type { CommetHTTPClient } from "../utils/http";
-import type { BillingInterval } from "./plans";
+import type { BillingInterval, FeatureType } from "./plans";
 
 export type SubscriptionStatus =
   | "draft"
@@ -15,7 +15,7 @@ export type SubscriptionStatus =
 export interface FeatureSummary {
   code: string;
   name: string;
-  type: "boolean" | "usage" | "seats";
+  type: FeatureType;
   enabled?: boolean;
   usage?: {
     current: number;


### PR DESCRIPTION
## Summary

- Adds `quota` as a top-level resource on the `Commet` client, mirroring the existing `seats` resource
- Five methods: `quota.add`, `quota.set`, `quota.remove` (mutations) + `quota.get`, `quota.getAll` (reads)
- Exports all quota types (`QuotaEvent`, `QuotaAllowance`, and all param types) from the package root
- Exposes `billedQuantity` on `QuotaAllowance` and `FeatureAccess` — the period high-water-mark the customer is billed for (peak units reached, locked in until renewal even if usage drops)

## Methods

| Method | HTTP | Notes |
|--------|------|-------|
| `quota.add({ customerId, featureCode, count? })` | `POST /usage/quota` | `count` defaults to `1` |
| `quota.set({ customerId, featureCode, count })` | `PUT /usage/quota` | exact value, required |
| `quota.remove({ customerId, featureCode, count? })` | `DELETE /usage/quota` | throws `insufficient_balance` on overdraft |
| `quota.get({ customerId, featureCode })` | `GET /usage/quota` | returns `QuotaAllowance` |
| `quota.getAll({ customerId })` | `GET /usage/quota/all` | returns `QuotaAllowance[]` |

## `QuotaAllowance` shape

```ts
{
  featureCode: string
  current: number           // units used right now
  included: number          // units in the plan
  remaining: number | null  // null when unlimited
  billedQuantity?: number   // period high-water-mark you're billed for (>= included)
  unlimited: boolean
  overageEnabled: boolean
  asOf: string | null       // ISO timestamp of last snapshot (null = no events yet)
}
```

`billedQuantity` reflects durable high-water-mark billing: once a customer peaks above their included amount, that peak is billed for the rest of the period and does not drop when usage decreases. Use it (not `current`) to show the effective billed limit.

## Test plan

- [x] Unit tests green (`pnpm test` in `packages/node`) — 61 passing
- [x] Typecheck passes (`pnpm typecheck`)
- [x] `billedQuantity` verified end-to-end against production (high-water-mark returned correctly after usage drops)
- [x] Changeset included (`packages/node/.changeset/quota-resource.md`, minor bump)
