### PR TITLE
test(node): assert customer id on the wire; fix vitest config [BIL-1509]

### DIFF
--- a/packages/node/src/__tests__/customers.test.ts
+++ b/packages/node/src/__tests__/customers.test.ts
@@ -9,7 +9,8 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 function lastBody(): Record<string, unknown> {
-  const call = vi.mocked(fetch).mock.calls.at(-1);
+  const calls = vi.mocked(fetch).mock.calls;
+  const call = calls[calls.length - 1];
   return JSON.parse((call?.[1] as RequestInit).body as string);
 }
 

--- a/packages/node/src/__tests__/customers.test.ts
+++ b/packages/node/src/__tests__/customers.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Commet } from "../client";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function lastBody(): Record<string, unknown> {
+  const call = vi.mocked(fetch).mock.calls.at(-1);
+  return JSON.parse((call?.[1] as RequestInit).body as string);
+}
+
+describe("Customers — id (external_id) on the wire", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("create sends id in the body", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse({ success: true, data: { id: "cus_x" } }),
+    );
+    const client = new Commet({ apiKey: "ck_test_123" });
+
+    await client.customers.create({ email: "a@b.com", id: "ext_123" });
+
+    const body = lastBody();
+    expect(body.id).toBe("ext_123");
+    expect(body.billingEmail).toBe("a@b.com");
+  });
+
+  it("create without id omits it", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse({ success: true, data: { id: "cus_x" } }),
+    );
+    const client = new Commet({ apiKey: "ck_test_123" });
+
+    await client.customers.create({ email: "a@b.com" });
+
+    expect(lastBody()).not.toHaveProperty("id");
+  });
+
+  it("createBatch sends id per customer", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse({ success: true, data: { successful: [], failed: [] } }),
+    );
+    const client = new Commet({ apiKey: "ck_test_123" });
+
+    await client.customers.createBatch({
+      customers: [
+        { email: "a@b.com", id: "ext_a" },
+        { email: "b@b.com" },
+      ],
+    });
+
+    const customers = lastBody().customers as Array<Record<string, unknown>>;
+    expect(customers[0].id).toBe("ext_a");
+    expect(customers[1]).not.toHaveProperty("id");
+  });
+});

--- a/packages/node/src/__tests__/http.test.ts
+++ b/packages/node/src/__tests__/http.test.ts
@@ -38,7 +38,7 @@ describe("CommetHTTPClient", () => {
       await client.get("/customers");
 
       expect(fetch).toHaveBeenCalledWith(
-        "https://commet.co/api/customers",
+        "https://commet.co/api/v1/customers",
         expect.any(Object),
       );
     });
@@ -83,7 +83,7 @@ describe("CommetHTTPClient", () => {
       await client.get("customers");
 
       expect(fetch).toHaveBeenCalledWith(
-        "https://commet.co/api/customers",
+        "https://commet.co/api/v1/customers",
         expect.any(Object),
       );
     });
@@ -122,7 +122,7 @@ describe("CommetHTTPClient", () => {
 
       const requestInit = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
       const headers = requestInit.headers as Record<string, string>;
-      expect(headers["Idempotency-Key"]).toMatch(/^sdk_/);
+      expect(headers["Idempotency-Key"]).toMatch(/^commet-node-retry-/);
     });
   });
 
@@ -147,7 +147,10 @@ describe("CommetHTTPClient", () => {
     it("includes statusCode and code on API error", async () => {
       const client = createClient({ retries: 0 });
       vi.mocked(fetch).mockResolvedValueOnce(
-        jsonResponse({ message: "Forbidden", code: "forbidden" }, 403),
+        jsonResponse(
+          { error: { message: "Forbidden", code: "forbidden" } },
+          403,
+        ),
       );
 
       try {
@@ -167,13 +170,15 @@ describe("CommetHTTPClient", () => {
       vi.mocked(fetch).mockResolvedValueOnce(
         jsonResponse(
           {
-            message: "Validation failed",
-            code: "validation_error",
-            details: [
-              { field: "email", message: "is required" },
-              { field: "email", message: "must be valid" },
-              { field: "name", message: "is too short" },
-            ],
+            error: {
+              message: "Validation failed",
+              code: "validation_error",
+              details: [
+                { field: "email", message: "is required" },
+                { field: "email", message: "must be valid" },
+                { field: "name", message: "is too short" },
+              ],
+            },
           },
           422,
         ),

--- a/packages/node/vitest.config.ts
+++ b/packages/node/vitest.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vitest/config";
+import pkg from "./package.json";
 
 export default defineConfig({
+  define: {
+    __SDK_VERSION__: JSON.stringify(pkg.version),
+  },
   test: {
     globals: true,
     environment: "node",


### PR DESCRIPTION
## Summary

- Wire-level tests added (`packages/node/src/__tests__/customers.test.ts`) using `vi.stubGlobal('fetch', vi.fn())` to capture the real request body
- Fixed `vitest.config.ts` to define `__SDK_VERSION__` (was only defined by tsup, not vitest)
- Aligned `http.test.ts` with current API shape (`/api/v1/`, nested error envelope, `commet-node-retry-` prefix)
- Node already sent `id` correctly — this adds the regression test

## Test plan

- [ ] `pnpm test` (from `packages/node`) — 56 tests pass
- [ ] Wire-level test captures `fetch` calls and asserts `id` is in the request body for `customers.create` and `customers.createBatch`

Closes BIL-1509