### PR TITLE
feat!: split features into catalog and feature-access (API 2026-06-10)

### DIFF
--- a/.changeset/better-auth-customer-features.md
+++ b/.changeset/better-auth-customer-features.md
@@ -1,0 +1,11 @@
+---
+"@commet/better-auth": patch
+---
+
+The Commet feature endpoints now read the signed-in user's access through the new `featureAccess` resource:
+
+- `GET /commet/features` uses `featureAccess.list({ customerId })`.
+- `GET /commet/features/:code` uses `featureAccess.get({ customerId, code })`.
+- `GET /commet/features/:code/check` and `GET /commet/features/:code/can-use` use `featureAccess.canUse({ customerId, code })`.
+
+Behavior is unchanged: each endpoint still returns the user's feature access for their active subscription.

--- a/.changeset/cli-feature-catalog.md
+++ b/.changeset/cli-feature-catalog.md
@@ -1,0 +1,11 @@
+---
+"commet": patch
+---
+
+The `features` command now manages the feature catalog: `commet features list` returns every feature definition in your organization and `commet features get --code <code>` fetches one. Checking a customer's access moved to the new `feature-access` command group:
+
+- `commet feature-access list --customer-id <id>`
+- `commet feature-access get --customer-id <id> --code <code>`
+- `commet feature-access can-use --customer-id <id> --code <code>`
+
+`commet pull` / `commet push` continue to read the catalog through `features.list()`; config sync behavior is unchanged.

--- a/.changeset/cli-payouts-test-clock-quota.md
+++ b/.changeset/cli-payouts-test-clock-quota.md
@@ -1,0 +1,9 @@
+---
+"commet": patch
+---
+
+Three new resource command groups complete the CLI's coverage of the @commet/node SDK surface:
+
+- `commet payouts` — `request --amount <n>`, `add-bank-account --account-number <number> --account-holder-name <name>`, `complete-verification --email <email> --business-type <type> --business-url <url> --document-url <url> --bank <json>`
+- `commet test-clock` — `get`, `advance --advance-days <n> | --frozen-time <ts>`, `process-billing` (sandbox only)
+- `commet quota` — `add`, `set`, `remove`, `get`, `get-all` for customer quota allowances by feature code

--- a/.changeset/feature-catalog-list.md
+++ b/.changeset/feature-catalog-list.md
@@ -1,0 +1,29 @@
+---
+"@commet/node": major
+---
+
+**Breaking:** Features are now split into a catalog surface and a per-customer access surface, matching the flat REST API.
+
+- `features.list()` returns the organization's feature catalog (`Feature[]`) — every feature you have defined. It no longer takes a `customerId`.
+- `features.get({ code })` returns a single catalog definition (`Feature`) by code.
+- A customer's feature access moved to the new `featureAccess` resource:
+  - `featureAccess.list({ customerId })` → `FeatureAccess[]` (everything the customer can use under their active subscription).
+  - `featureAccess.get({ customerId, code })` → `FeatureLookup` (access details for one feature).
+  - `featureAccess.canUse({ customerId, code })` → `FeatureLookup` (whether the customer can consume one more unit).
+- Active add-ons now require a `customerId`: `addons.listActive({ customerId })` → `ActiveAddon[]`.
+
+Migration:
+
+```ts
+// Feature catalog (definitions)
+const { data: catalog } = await commet.features.list();
+const { data: feature } = await commet.features.get({ code: "api_calls" });
+
+// Customer feature access (what they can use)
+const { data: access } = await commet.featureAccess.list({ customerId });
+const { data: lookup } = await commet.featureAccess.get({ customerId, code: "api_calls" });
+const { data: check } = await commet.featureAccess.canUse({ customerId, code: "api_calls" });
+
+// Active add-ons now require a customer
+const { data: addons } = await commet.addons.listActive({ customerId });
+```

--- a/examples/fixed/app/(dashboard)/dashboard/page.tsx
+++ b/examples/fixed/app/(dashboard)/dashboard/page.tsx
@@ -22,7 +22,7 @@ export default async function DashboardPage() {
 
   const results = await Promise.all(
     FEATURE_CODES.map((code) =>
-      commet.features.canUse({ customerId: user!.id, code }),
+      commet.featureAccess.canUse({ customerId: user!.id, code }),
     ),
   );
 

--- a/examples/metered/app/(dashboard)/dashboard/page.tsx
+++ b/examples/metered/app/(dashboard)/dashboard/page.tsx
@@ -16,7 +16,7 @@ export default async function DashboardPage() {
 
   const results = await Promise.all(
     FEATURE_CODES.map((code) =>
-      commet.features.canUse({ customerId: user!.id, code }),
+      commet.featureAccess.canUse({ customerId: user!.id, code }),
     ),
   );
 

--- a/examples/quota/actions/tasks.ts
+++ b/examples/quota/actions/tasks.ts
@@ -193,7 +193,7 @@ export async function getTaskQuotaStatusAction(): Promise<TaskQuotaStatus> {
       };
     }
 
-    const feature = await commet.features.get({
+    const feature = await commet.featureAccess.get({
       customerId: user.id,
       code: TASKS_FEATURE_CODE,
     });

--- a/examples/seats/actions/team.ts
+++ b/examples/seats/actions/team.ts
@@ -53,7 +53,7 @@ export async function inviteMemberAction(
       return { success: false, error: "Not authenticated" };
     }
 
-    const canAdd = await commet.features.canUse({
+    const canAdd = await commet.featureAccess.canUse({
       customerId: user.id,
       code: "member",
     });
@@ -227,7 +227,7 @@ export async function checkSubscriptionStatusAction(): Promise<SubscriptionStatu
     const isActive =
       subscription.status === "active" || subscription.status === "trialing";
 
-    const seatResult = await commet.features.get({
+    const seatResult = await commet.featureAccess.get({
       customerId: user.id,
       code: "member",
     });

--- a/packages/ai-sdk/README.md
+++ b/packages/ai-sdk/README.md
@@ -67,7 +67,7 @@ const result = streamText({
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
 | `commet` | `Commet` | Yes | Commet SDK instance |
-| `feature` | `GeneratedFeatureCode` | Yes | Feature code to track usage against |
+| `feature` | `string` | Yes | Feature code to track usage against |
 | `customerId` | `string` | Yes | Commet customer ID (`cus_*`) or external ID |
 | `idempotencyKey` | `string` | No | Prevent duplicate tracking for retries |
 | `onTrackingError` | `(error: Error) => void` | No | Custom error handler. Defaults to `console.warn` |
@@ -85,7 +85,7 @@ Tracking runs in the stream's `flush` phase — it completes before the HTTP con
 ## Requirements
 
 - `ai` >= 6.0.0
-- `@commet/node` >= 1.6.0
+- `@commet/node` >= 7.0.0
 
 ## Documentation
 

--- a/packages/better-auth/README.md
+++ b/packages/better-auth/README.md
@@ -18,7 +18,7 @@ Full billing integration between [Better Auth](https://www.better-auth.com) and 
 ## Installation
 
 ```bash
-pnpm add @commet/better-auth@^1.0.0 @commet/node@^1.0.0 better-auth
+pnpm add @commet/better-auth @commet/node better-auth
 ```
 
 ## Preparation
@@ -101,7 +101,7 @@ export const authClient = createAuthClient({
 // Always query current state - no webhooks needed!
 const { data: subscription } = await authClient.subscription.get();
 const { data: features } = await authClient.features.list();
-const { data: canUse } = await authClient.features.canUse({ code: "api_calls" });
+const { data: canUse } = await authClient.features.canUse("api_calls");
 ```
 
 Webhooks are only useful if you want to:
@@ -124,7 +124,6 @@ commet({
   // Optional: Customize customer creation parameters
   getCustomerCreateParams: ({ user }) => ({
     fullName: user.name,
-    domain: "example.com",
     metadata: { plan: "starter" }
   }),
   
@@ -201,17 +200,17 @@ await authClient.subscription.cancel({
 const { data: features } = await authClient.features.list();
 
 // Get specific feature
-const { data: feature } = await authClient.features.get({ code: "team_members" });
+const { data: feature } = await authClient.features.get("team_members");
 console.log(feature?.current, feature?.included, feature?.remaining);
 
 // Check if feature is enabled (boolean)
-const { data: check } = await authClient.features.check({ code: "custom_branding" });
+const { data: check } = await authClient.features.check("custom_branding");
 if (!check?.allowed) {
   redirect("/upgrade");
 }
 
 // Check if user can use one more unit
-const { data: canUse } = await authClient.features.canUse({ code: "api_calls" });
+const { data: canUse } = await authClient.features.canUse("api_calls");
 if (!canUse?.allowed) {
   return { error: "Limit reached. Please upgrade." };
 }
@@ -261,10 +260,8 @@ await authClient.seats.set({
 
 // Set all seat types at once
 await authClient.seats.setAll({
-  seats: {
-    editor: 10,
-    viewer: 50
-  }
+  editor: 10,
+  viewer: 50
 });
 ```
 

--- a/packages/better-auth/src/plugins/features.ts
+++ b/packages/better-auth/src/plugins/features.ts
@@ -36,7 +36,9 @@ export const features =
           }
 
           try {
-            const result = await commet.features.list({ customerId: userId });
+            const result = await commet.featureAccess.list({
+              customerId: userId,
+            });
 
             if (!result.success) {
               throw new APIError("INTERNAL_SERVER_ERROR", {
@@ -86,7 +88,7 @@ export const features =
           }
 
           try {
-            const result = await commet.features.get({
+            const result = await commet.featureAccess.get({
               customerId: userId,
               code,
             });
@@ -139,7 +141,7 @@ export const features =
           }
 
           try {
-            const result = await commet.features.canUse({
+            const result = await commet.featureAccess.canUse({
               customerId: userId,
               code,
             });
@@ -192,7 +194,7 @@ export const features =
           }
 
           try {
-            const result = await commet.features.canUse({
+            const result = await commet.featureAccess.canUse({
               customerId: userId,
               code,
             });

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -46,12 +46,12 @@ const commet = new Commet({ apiKey: '...' });
 
 await commet.usage.track({
   feature: 'api_calls', // Autocomplete works!
-  externalId: 'user_123'
+  customerId: 'cus_123'
 });
 
 await commet.subscriptions.create({
   planCode: 'pro', // Autocomplete with your plans!
-  externalId: 'user_123'
+  customerId: 'cus_123'
 });
 ```
 
@@ -61,11 +61,13 @@ await commet.subscriptions.create({
 commet login           # Authenticate with Commet
 commet logout          # Remove credentials
 commet link            # Link project to organization
-commet pull            # Generate TypeScript types
-commet info            # Show project status
-commet list features   # List features
-commet list seats      # List seat types
-commet list plans      # List plans
+commet orgs            # List your organizations
+commet pull            # Fetch billing config and generate commet.config.ts
+commet push            # Push commet.config.ts to Commet
+commet listen <url>    # Forward webhook events to your local server
+commet features list   # List the feature catalog
+commet plans list      # List plans
+commet customers list  # List customers
 ```
 
 ## Documentation

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -1,65 +1,44 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import type { BillingConfig, Feature, FeatureDef } from "@commet/node";
 import { confirm } from "@inquirer/prompts";
 import chalk from "chalk";
 import { Command } from "commander";
 import ora from "ora";
-import { apiRequest, BASE_URL } from "../utils/api";
-import {
-  findConfigFile,
-  type LoadedConfig,
-  loadBillingConfig,
-} from "../utils/config-loader";
+import { findConfigFile, loadBillingConfig } from "../utils/config-loader";
 import { computeDiff, formatDiff, type RemoteState } from "../utils/diff";
 import { generateConfigFile } from "../utils/generator";
 import { isAgentMode, requireOrgContext } from "../utils/output";
-
-interface Feature {
-  id: string;
-  publicId: string;
-  code: string;
-  name: string;
-  description?: string | null;
-  type: "boolean" | "usage" | "seats";
-  unitName?: string | null;
-}
-
-interface Plan {
-  id: string;
-  publicId: string;
-  code: string;
-  name: string;
-  description?: string | null;
-  consumptionModel?: "metered" | "credits" | "balance" | null;
-  isFree?: boolean;
-  isPublic?: boolean;
-  sortOrder?: number;
-  prices?: Array<{
-    billingInterval: string;
-    price: number;
-    trialDays?: number | null;
-    isDefault?: boolean;
-  }>;
-  features?: Array<{
-    featureCode: string;
-    enabled?: boolean | null;
-    includedAmount?: number | null;
-    unlimited?: boolean | null;
-    overageEnabled?: boolean | null;
-    overageUnitPrice?: number | null;
-  }>;
-}
-
-interface ConfigResponse {
-  success: boolean;
-  features: Feature[];
-  plans: Plan[];
-}
+import { createSdkClient, fetchRemoteState } from "../utils/sdk";
 
 interface PullOptions {
   yes?: boolean;
   dryRun?: boolean;
   output?: string;
+}
+
+function toFeatureDef(feature: Feature): FeatureDef {
+  if (feature.type === "boolean") {
+    return {
+      name: feature.name,
+      type: "boolean",
+      ...(feature.description ? { description: feature.description } : {}),
+    };
+  }
+  if (feature.type === "seats") {
+    return {
+      name: feature.name,
+      type: "seats",
+      ...(feature.unitName ? { unitName: feature.unitName } : {}),
+      ...(feature.description ? { description: feature.description } : {}),
+    };
+  }
+  return {
+    name: feature.name,
+    type: "usage",
+    ...(feature.unitName ? { unitName: feature.unitName } : {}),
+    ...(feature.description ? { description: feature.description } : {}),
+  };
 }
 
 export const pullCommand = new Command("pull")
@@ -86,30 +65,28 @@ Examples:
   )
   .action(async (options: PullOptions) => {
     const agentMode = isAgentMode(options);
-    const { orgId } = requireOrgContext();
+    requireOrgContext();
 
     const spinner = agentMode
       ? null
       : ora("Fetching config from remote...").start();
 
-    const orgQuery = orgId === "__from_api_key__" ? "" : `?orgId=${orgId}`;
-    const result = await apiRequest<ConfigResponse>(
-      `${BASE_URL}/api/cli/pull${orgQuery}`,
-    );
+    const commet = createSdkClient();
+    const remoteState = await fetchRemoteState(commet);
 
-    if (result.error || !result.data) {
+    if ("error" in remoteState) {
       if (agentMode) {
-        console.log(JSON.stringify({ error: result.error }));
+        console.log(JSON.stringify({ error: remoteState.error }));
       } else {
         spinner?.fail("Failed to fetch config");
-        console.error(chalk.red("Error:"), result.error?.message);
+        console.error(chalk.red("Error:"), remoteState.error.message);
       }
       process.exit(1);
     }
 
     spinner?.succeed("Remote state fetched");
 
-    const { features, plans } = result.data;
+    const { features, plans } = remoteState;
     const configContent = generateConfigFile(features, plans);
     const outputPath = path.resolve(process.cwd(), "commet.config.ts");
 
@@ -205,17 +182,9 @@ Examples:
 
     const localConfig = localLoaded.config;
 
-    const remoteAsConfig: LoadedConfig = {
+    const remoteAsConfig: BillingConfig = {
       features: Object.fromEntries(
-        features.map((f) => [
-          f.code,
-          {
-            name: f.name,
-            type: f.type,
-            ...(f.unitName ? { unitName: f.unitName } : {}),
-            ...(f.description ? { description: f.description } : {}),
-          },
-        ]),
+        features.map((f) => [f.code, toFeatureDef(f)]),
       ),
       plans: Object.fromEntries(
         plans.map((p) => [
@@ -251,24 +220,20 @@ Examples:
         code,
         name: f.name,
         type: f.type,
-        description: f.description ?? null,
-        unitName: f.unitName ?? null,
+        unitName: "unitName" in f ? (f.unitName ?? null) : null,
       })),
       plans: Object.entries(localConfig.plans).map(([code, p]) => ({
         code,
         name: p.name,
-        description: p.description ?? null,
-        consumptionModel: p.consumptionModel ?? null,
-        defaultInterval: p.defaultInterval ?? null,
-        isFree: p.isFree,
-        isPublic: p.isPublic,
-        sortOrder: p.sortOrder,
         prices: p.prices.map((pr) => ({
           billingInterval: pr.interval,
           price: pr.amount,
-          trialDays: pr.trialDays ?? null,
         })),
-        features: [],
+        features: p.features
+          ? Object.keys(p.features).map((featureCode) => ({
+              code: featureCode,
+            }))
+          : [],
       })),
     };
 

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -4,14 +4,9 @@ import { Command } from "commander";
 import ora from "ora";
 import { apiRequest, BASE_URL } from "../utils/api";
 import { loadBillingConfig } from "../utils/config-loader";
-import { computeDiff, formatDiff, type RemoteState } from "../utils/diff";
+import { computeDiff, formatDiff } from "../utils/diff";
 import { isAgentMode, requireOrgContext } from "../utils/output";
-
-interface ConfigResponse {
-  success: boolean;
-  features: RemoteState["features"];
-  plans: RemoteState["plans"];
-}
+import { createSdkClient, fetchRemoteState } from "../utils/sdk";
 
 interface PushResponse {
   success: boolean;
@@ -89,29 +84,22 @@ Examples:
       ? null
       : ora("Fetching remote state...").start();
 
-    const orgQuery = orgId === "__from_api_key__" ? "" : `?orgId=${orgId}`;
-    const remoteResult = await apiRequest<ConfigResponse>(
-      `${BASE_URL}/api/cli/pull${orgQuery}`,
-    );
+    const commet = createSdkClient();
+    const remoteState = await fetchRemoteState(commet);
 
-    if (remoteResult.error || !remoteResult.data) {
+    if ("error" in remoteState) {
       if (agentMode) {
-        console.log(JSON.stringify({ error: remoteResult.error }));
+        console.log(JSON.stringify({ error: remoteState.error }));
       } else {
         fetchSpinner?.fail("Failed to fetch remote state");
-        console.error(chalk.red("Error:"), remoteResult.error?.message);
+        console.error(chalk.red("Error:"), remoteState.error.message);
       }
       process.exit(1);
     }
 
     fetchSpinner?.succeed("Remote state fetched");
 
-    const remote: RemoteState = {
-      features: remoteResult.data.features,
-      plans: remoteResult.data.plans,
-    };
-
-    const diff = computeDiff(config, remote);
+    const diff = computeDiff(config, remoteState);
 
     if (agentMode) {
       if (options.dryRun) {

--- a/packages/cli/src/commands/resources/registry.ts
+++ b/packages/cli/src/commands/resources/registry.ts
@@ -1011,54 +1011,23 @@ const plansResource: ResourceDef = {
 
 const featuresResource: ResourceDef = {
   name: "features",
-  description: "Manage features and check feature access",
+  description: "Manage the feature catalog",
   sdkProperty: "features",
   actions: {
-    get: {
-      method: "get",
-      description: "Get feature access for a customer",
-      params: [
-        {
-          flag: "--customer-id <id>",
-          description: "Customer ID",
-          required: true,
-          sdkKey: "customerId",
-        },
-        {
-          flag: "--code <code>",
-          description: "Feature code",
-          required: true,
-          sdkKey: "code",
-        },
-      ],
-    },
-    "can-use": {
-      method: "canUse",
-      description: "Check if a customer can use a feature",
-      params: [
-        {
-          flag: "--customer-id <id>",
-          description: "Customer ID",
-          required: true,
-          sdkKey: "customerId",
-        },
-        {
-          flag: "--code <code>",
-          description: "Feature code",
-          required: true,
-          sdkKey: "code",
-        },
-      ],
-    },
     list: {
       method: "list",
-      description: "List features for a customer",
+      description: "List every feature in the organization catalog",
+      params: [],
+    },
+    get: {
+      method: "get",
+      description: "Get a feature definition from the catalog by code",
       params: [
         {
-          flag: "--customer-id <id>",
-          description: "Customer ID",
+          flag: "--code <code>",
+          description: "Feature code",
           required: true,
-          sdkKey: "customerId",
+          sdkKey: "code",
         },
       ],
     },
@@ -1127,6 +1096,62 @@ const featuresResource: ResourceDef = {
       method: "delete",
       description: "Delete a feature",
       params: [
+        {
+          flag: "--code <code>",
+          description: "Feature code",
+          required: true,
+          sdkKey: "code",
+        },
+      ],
+    },
+  },
+};
+
+const featureAccessResource: ResourceDef = {
+  name: "feature-access",
+  description: "Check a customer's feature access and usage",
+  sdkProperty: "featureAccess",
+  actions: {
+    list: {
+      method: "list",
+      description: "List feature access for a customer",
+      params: [
+        {
+          flag: "--customer-id <id>",
+          description: "Customer ID",
+          required: true,
+          sdkKey: "customerId",
+        },
+      ],
+    },
+    get: {
+      method: "get",
+      description: "Get feature access details for a customer",
+      params: [
+        {
+          flag: "--customer-id <id>",
+          description: "Customer ID",
+          required: true,
+          sdkKey: "customerId",
+        },
+        {
+          flag: "--code <code>",
+          description: "Feature code",
+          required: true,
+          sdkKey: "code",
+        },
+      ],
+    },
+    "can-use": {
+      method: "canUse",
+      description: "Check if a customer can use one more unit of a feature",
+      params: [
+        {
+          flag: "--customer-id <id>",
+          description: "Customer ID",
+          required: true,
+          sdkKey: "customerId",
+        },
         {
           flag: "--code <code>",
           description: "Feature code",
@@ -2353,6 +2378,7 @@ export const resourceDefinitions: ResourceDef[] = [
   subscriptionsResource,
   plansResource,
   featuresResource,
+  featureAccessResource,
   seatsResource,
   usageResource,
   portalResource,

--- a/packages/cli/src/commands/resources/registry.ts
+++ b/packages/cli/src/commands/resources/registry.ts
@@ -2373,6 +2373,290 @@ const planGroupsResource: ResourceDef = {
   },
 };
 
+const payoutsResource: ResourceDef = {
+  name: "payouts",
+  description: "Manage payouts",
+  sdkProperty: "payouts",
+  actions: {
+    request: {
+      method: "request",
+      description: "Request a payout of available balance",
+      params: [
+        {
+          flag: "--amount <n>",
+          description: "Amount in cents (USD, minimum 1000)",
+          required: true,
+          parse: parseNumber,
+          sdkKey: "amount",
+        },
+        {
+          flag: "--description <desc>",
+          description: "Payout description",
+          sdkKey: "description",
+        },
+      ],
+    },
+    "add-bank-account": {
+      method: "addBankAccount",
+      description: "Add a destination bank account to the payout account",
+      params: [
+        {
+          flag: "--account-number <number>",
+          description: "Bank account number",
+          required: true,
+          sdkKey: "accountNumber",
+        },
+        {
+          flag: "--account-holder-name <name>",
+          description: "Account holder name",
+          required: true,
+          sdkKey: "accountHolderName",
+        },
+        {
+          flag: "--routing-number <number>",
+          description: "Routing number",
+          sdkKey: "routingNumber",
+        },
+        {
+          flag: "--account-type <type>",
+          description: "Account type: checking or savings",
+          sdkKey: "accountType",
+        },
+        {
+          flag: "--set-default <bool>",
+          description: "Set as default bank account",
+          parse: parseBool,
+          sdkKey: "setDefault",
+        },
+      ],
+    },
+    "complete-verification": {
+      method: "completeVerification",
+      description: "Provision the payout account with the full KYC payload",
+      params: [
+        {
+          flag: "--email <email>",
+          description: "Contact email",
+          required: true,
+          sdkKey: "email",
+        },
+        {
+          flag: "--business-type <type>",
+          description: "Business type: individual or company",
+          required: true,
+          sdkKey: "businessType",
+        },
+        {
+          flag: "--business-url <url>",
+          description: "Business website URL",
+          required: true,
+          sdkKey: "businessUrl",
+        },
+        {
+          flag: "--document-url <url>",
+          description: "Identity document URL",
+          required: true,
+          sdkKey: "documentUrl",
+        },
+        {
+          flag: "--bank <json>",
+          description:
+            "Bank account (JSON: {accountNumber, accountHolderName, ...})",
+          required: true,
+          parse: parseJson,
+          sdkKey: "bank",
+        },
+        {
+          flag: "--individual <json>",
+          description: "Individual KYC details (JSON, individual businesses)",
+          parse: parseJson,
+          sdkKey: "individual",
+        },
+        {
+          flag: "--company <json>",
+          description: "Company KYC details (JSON, company businesses)",
+          parse: parseJson,
+          sdkKey: "company",
+        },
+      ],
+    },
+  },
+};
+
+const testClockResource: ResourceDef = {
+  name: "test-clock",
+  description: "Control the sandbox test clock",
+  sdkProperty: "testClock",
+  actions: {
+    get: {
+      method: "get",
+      description: "Get the current test clock state (sandbox only)",
+      params: [],
+    },
+    advance: {
+      method: "advance",
+      description: "Move the test clock forward (sandbox only)",
+      params: [
+        {
+          flag: "--advance-days <n>",
+          description: "Days to move the clock forward",
+          parse: parseNumber,
+          sdkKey: "advanceDays",
+        },
+        {
+          flag: "--frozen-time <ts>",
+          description: "Absolute instant to move to (ISO 8601)",
+          sdkKey: "frozenTime",
+        },
+      ],
+    },
+    "process-billing": {
+      method: "processBilling",
+      description:
+        "Enqueue billing cycles for customers due at the simulated time (sandbox only)",
+      params: [],
+    },
+  },
+};
+
+const quotaResource: ResourceDef = {
+  name: "quota",
+  description: "Manage quota allowances",
+  sdkProperty: "quota",
+  actions: {
+    add: {
+      method: "add",
+      description: "Add to a customer's quota allowance for a feature",
+      params: [
+        {
+          flag: "--feature-code <code>",
+          description: "Feature code",
+          required: true,
+          sdkKey: "featureCode",
+        },
+        {
+          flag: "--customer-id <id>",
+          description: "Customer ID (provide this or --external-id)",
+          sdkKey: "customerId",
+        },
+        {
+          flag: "--external-id <id>",
+          description: "Customer external ID (provide this or --customer-id)",
+          sdkKey: "externalId",
+        },
+        {
+          flag: "--count <n>",
+          description: "Amount to add (defaults to 1)",
+          parse: parseNumber,
+          sdkKey: "count",
+        },
+        {
+          flag: "--idempotency-key <key>",
+          description: "Idempotency key for deduplication",
+          sdkKey: "idempotencyKey",
+        },
+      ],
+    },
+    set: {
+      method: "set",
+      description: "Set a customer's quota allowance to an exact value",
+      params: [
+        {
+          flag: "--feature-code <code>",
+          description: "Feature code",
+          required: true,
+          sdkKey: "featureCode",
+        },
+        {
+          flag: "--count <n>",
+          description: "Exact allowance value",
+          required: true,
+          parse: parseNumber,
+          sdkKey: "count",
+        },
+        {
+          flag: "--customer-id <id>",
+          description: "Customer ID (provide this or --external-id)",
+          sdkKey: "customerId",
+        },
+        {
+          flag: "--external-id <id>",
+          description: "Customer external ID (provide this or --customer-id)",
+          sdkKey: "externalId",
+        },
+        {
+          flag: "--idempotency-key <key>",
+          description: "Idempotency key for deduplication",
+          sdkKey: "idempotencyKey",
+        },
+      ],
+    },
+    remove: {
+      method: "remove",
+      description: "Remove from a customer's quota allowance for a feature",
+      params: [
+        {
+          flag: "--feature-code <code>",
+          description: "Feature code",
+          required: true,
+          sdkKey: "featureCode",
+        },
+        {
+          flag: "--customer-id <id>",
+          description: "Customer ID (provide this or --external-id)",
+          sdkKey: "customerId",
+        },
+        {
+          flag: "--external-id <id>",
+          description: "Customer external ID (provide this or --customer-id)",
+          sdkKey: "externalId",
+        },
+        {
+          flag: "--count <n>",
+          description: "Amount to remove (defaults to 1)",
+          parse: parseNumber,
+          sdkKey: "count",
+        },
+        {
+          flag: "--idempotency-key <key>",
+          description: "Idempotency key for deduplication",
+          sdkKey: "idempotencyKey",
+        },
+      ],
+    },
+    get: {
+      method: "get",
+      description: "Get the quota allowance for a specific feature",
+      params: [
+        {
+          flag: "--customer-id <id>",
+          description: "Customer ID",
+          required: true,
+          sdkKey: "customerId",
+        },
+        {
+          flag: "--feature-code <code>",
+          description: "Feature code",
+          required: true,
+          sdkKey: "featureCode",
+        },
+      ],
+    },
+    "get-all": {
+      method: "getAll",
+      description: "Get all quota allowances for a customer",
+      params: [
+        {
+          flag: "--customer-id <id>",
+          description: "Customer ID",
+          required: true,
+          sdkKey: "customerId",
+        },
+      ],
+    },
+  },
+};
+
 export const resourceDefinitions: ResourceDef[] = [
   customersResource,
   subscriptionsResource,
@@ -2390,4 +2674,7 @@ export const resourceDefinitions: ResourceDef[] = [
   transactionsResource,
   promoCodesResource,
   planGroupsResource,
+  payoutsResource,
+  testClockResource,
+  quotaResource,
 ];

--- a/packages/cli/src/utils/config-loader.ts
+++ b/packages/cli/src/utils/config-loader.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import type { BillingConfig } from "@commet/node";
 import { createJiti } from "jiti";
 
 const CONFIG_NAMES = [
@@ -7,44 +8,6 @@ const CONFIG_NAMES = [
   "commet.config.js",
   "commet.config.mjs",
 ];
-
-export interface LoadedConfig {
-  features: Record<
-    string,
-    {
-      name: string;
-      type: "boolean" | "usage" | "seats";
-      unitName?: string;
-      description?: string;
-    }
-  >;
-  plans: Record<
-    string,
-    {
-      name: string;
-      description?: string;
-      consumptionModel?: "metered" | "credits" | "balance";
-      defaultInterval?: string;
-      isFree?: boolean;
-      isPublic?: boolean;
-      sortOrder?: number;
-      prices: Array<{
-        interval: string;
-        amount: number;
-        trialDays?: number;
-      }>;
-      features?: Record<
-        string,
-        | boolean
-        | {
-            included?: number;
-            unlimited?: boolean;
-            overage?: { unitPrice: number };
-          }
-      >;
-    }
-  >;
-}
 
 export function findConfigFile(cwd: string): string | null {
   for (const name of CONFIG_NAMES) {
@@ -58,7 +21,7 @@ export function findConfigFile(cwd: string): string | null {
 
 export async function loadBillingConfig(
   cwd: string,
-): Promise<{ config: LoadedConfig; configPath: string }> {
+): Promise<{ config: BillingConfig; configPath: string }> {
   const configPath = findConfigFile(cwd);
   if (!configPath) {
     throw new Error(
@@ -80,7 +43,7 @@ export async function loadBillingConfig(
     );
   }
 
-  const config = moduleRecord.default as LoadedConfig;
+  const config = moduleRecord.default as BillingConfig;
 
   validateConfig(config, configPath);
 
@@ -96,7 +59,7 @@ const VALID_INTERVALS = new Set([
   "one_time",
 ]);
 
-function validateConfig(config: LoadedConfig, configPath: string): void {
+function validateConfig(config: BillingConfig, configPath: string): void {
   if (!config || typeof config !== "object") {
     throw new Error(`${configPath}: config must be an object`);
   }

--- a/packages/cli/src/utils/diff.ts
+++ b/packages/cli/src/utils/diff.ts
@@ -1,41 +1,19 @@
+import type { BillingConfig, Feature, Plan } from "@commet/node";
 import chalk from "chalk";
-import type { LoadedConfig } from "./config-loader";
 
-export interface RemoteFeature {
+type SdkPlanPrice = NonNullable<Plan["prices"]>[number];
+type SdkPlanFeature = NonNullable<Plan["features"]>[number];
+
+type RemoteFeature = Pick<Feature, "code" | "name" | "type" | "unitName">;
+type RemotePlanPrice = Pick<SdkPlanPrice, "billingInterval" | "price"> &
+  Partial<Pick<SdkPlanPrice, "isDefault">>;
+type RemotePlanFeature = Pick<SdkPlanFeature, "code">;
+
+interface RemotePlan {
   code: string;
   name: string;
-  type: string;
-  description?: string | null;
-  unitName?: string | null;
-}
-
-export interface RemotePlanPrice {
-  billingInterval: string;
-  price: number;
-  trialDays?: number | null;
-  isDefault?: boolean;
-}
-
-export interface RemotePlanFeature {
-  featureCode: string;
-  enabled?: boolean | null;
-  includedAmount?: number | null;
-  unlimited?: boolean | null;
-  overageEnabled?: boolean | null;
-  overageUnitPrice?: number | null;
-}
-
-export interface RemotePlan {
-  code: string;
-  name: string;
-  description?: string | null;
-  consumptionModel?: string | null;
-  defaultInterval?: string | null;
-  isFree?: boolean;
-  isPublic?: boolean;
-  sortOrder?: number;
-  prices: RemotePlanPrice[];
-  features: RemotePlanFeature[];
+  prices?: RemotePlanPrice[];
+  features?: RemotePlanFeature[];
 }
 
 export interface RemoteState {
@@ -68,7 +46,7 @@ export interface ConfigDiff {
 }
 
 export function computeDiff(
-  config: LoadedConfig,
+  config: BillingConfig,
   remote: RemoteState,
 ): ConfigDiff {
   const remoteFeatureMap = new Map(remote.features.map((f) => [f.code, f]));
@@ -124,10 +102,9 @@ export function computeDiff(
       changes.push(`name: "${remotePlan.name}" → "${localPlan.name}"`);
     }
 
+    const remotePrices = remotePlan.prices ?? [];
     const remoteDefaultInterval =
-      remotePlan.defaultInterval ??
-      remotePlan.prices.find((p) => p.isDefault)?.billingInterval ??
-      null;
+      remotePrices.find((p) => p.isDefault)?.billingInterval ?? null;
     if (
       localPlan.defaultInterval &&
       remoteDefaultInterval !== localPlan.defaultInterval
@@ -139,7 +116,7 @@ export function computeDiff(
 
     const localPriceMap = new Map(localPlan.prices.map((p) => [p.interval, p]));
     const remotePriceMap = new Map(
-      remotePlan.prices.map((p) => [p.billingInterval, p]),
+      remotePrices.map((p) => [p.billingInterval, p]),
     );
 
     for (const [interval, localPrice] of localPriceMap) {
@@ -157,7 +134,7 @@ export function computeDiff(
 
     if (localPlan.features) {
       const remotePlanFeatureMap = new Map(
-        remotePlan.features.map((f) => [f.featureCode, f]),
+        (remotePlan.features ?? []).map((f) => [f.code, f]),
       );
       for (const featureCode of Object.keys(localPlan.features)) {
         if (!remotePlanFeatureMap.has(featureCode)) {

--- a/packages/cli/src/utils/generator.ts
+++ b/packages/cli/src/utils/generator.ts
@@ -1,35 +1,4 @@
-interface Feature {
-  code: string;
-  name: string;
-  description?: string | null;
-  type: string;
-  unitName?: string | null;
-}
-
-interface Plan {
-  code: string;
-  name: string;
-  description?: string | null;
-  consumptionModel?: string | null;
-  defaultInterval?: string | null;
-  isFree?: boolean;
-  isPublic?: boolean;
-  sortOrder?: number;
-  prices?: Array<{
-    billingInterval: string;
-    price: number;
-    trialDays?: number | null;
-    isDefault?: boolean;
-  }>;
-  features?: Array<{
-    featureCode: string;
-    enabled?: boolean | null;
-    includedAmount?: number | null;
-    unlimited?: boolean | null;
-    overageEnabled?: boolean | null;
-    overageUnitPrice?: number | null;
-  }>;
-}
+import type { Feature, Plan } from "@commet/node";
 
 export function generateConfigFile(features: Feature[], plans: Plan[]): string {
   const lines: string[] = [];
@@ -61,7 +30,6 @@ export function generateConfigFile(features: Feature[], plans: Plan[]): string {
 
     const prices = p.prices ?? [];
     const defaultInterval =
-      p.defaultInterval ??
       prices.find((pr) => pr.isDefault)?.billingInterval ??
       prices[0]?.billingInterval;
     if (defaultInterval)
@@ -86,22 +54,23 @@ export function generateConfigFile(features: Feature[], plans: Plan[]): string {
     if (planFeatures.length > 0) {
       lines.push("      features: {");
       for (const pf of planFeatures) {
-        const featureDef = features.find((f) => f.code === pf.featureCode);
-        const isBoolean = featureDef?.type === "boolean";
+        const isSimpleBoolean =
+          pf.includedAmount == null && !pf.unlimited && !pf.overage?.enabled;
 
-        if (isBoolean) {
-          lines.push(`        ${pf.featureCode}: ${pf.enabled ?? true},`);
+        if (isSimpleBoolean) {
+          lines.push(`        ${pf.code}: ${pf.enabled},`);
         } else {
           const parts: string[] = [];
-          if (pf.includedAmount) parts.push(`included: ${pf.includedAmount}`);
+          if (pf.includedAmount != null)
+            parts.push(`included: ${pf.includedAmount}`);
           if (pf.unlimited) parts.push("unlimited: true");
-          if (pf.overageEnabled && pf.overageUnitPrice) {
-            parts.push(`overage: { unitPrice: ${pf.overageUnitPrice} }`);
+          if (pf.overage?.enabled && pf.overage.unitPrice != null) {
+            parts.push(`overage: { unitPrice: ${pf.overage.unitPrice} }`);
           }
           if (parts.length > 0) {
-            lines.push(`        ${pf.featureCode}: { ${parts.join(", ")} },`);
+            lines.push(`        ${pf.code}: { ${parts.join(", ")} },`);
           } else {
-            lines.push(`        ${pf.featureCode}: {},`);
+            lines.push(`        ${pf.code}: {},`);
           }
         }
       }

--- a/packages/cli/src/utils/sdk.ts
+++ b/packages/cli/src/utils/sdk.ts
@@ -1,4 +1,4 @@
-import { Commet } from "@commet/node";
+import { Commet, type Feature, type Plan } from "@commet/node";
 import { loadProjectConfig } from "./config";
 import { exitWithError } from "./output";
 
@@ -19,4 +19,33 @@ export function createSdkClient(): Commet {
       "No API key found. Set COMMET_API_KEY env var, or run `commet link` to auto-generate one.",
     action: "commet link",
   });
+}
+
+export async function fetchRemoteState(
+  commet: Commet,
+): Promise<
+  | { features: Feature[]; plans: Plan[] }
+  | { error: { code: string; message: string } }
+> {
+  const featuresResponse = await commet.features.list();
+  if (!featuresResponse.success || !featuresResponse.data) {
+    return {
+      error: {
+        code: "fetch_features_failed",
+        message: featuresResponse.error?.message ?? "Failed to fetch features",
+      },
+    };
+  }
+
+  const plansResponse = await commet.plans.list({ includePrivate: "true" });
+  if (!plansResponse.success || !plansResponse.data) {
+    return {
+      error: {
+        code: "fetch_plans_failed",
+        message: plansResponse.error?.message ?? "Failed to fetch plans",
+      },
+    };
+  }
+
+  return { features: featuresResponse.data, plans: plansResponse.data };
 }

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -95,7 +95,7 @@ Webhooks are optional in Commet. You can always query the current state directly
 
 ```typescript
 const subscription = await commet.subscriptions.getActive({ customerId: userId });
-const features = await commet.features.list({ externalId: userId });
+const features = await commet.featureAccess.list({ customerId: userId });
 ```
 
 Webhooks are useful when you want to react immediately to changes — send emails, update your database, revoke access, etc.

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -48,12 +48,12 @@ const commet = new Commet({
 // Create a customer
 const customer = await commet.customers.create({
   fullName: 'Acme Corp',
-  billingEmail: 'billing@acme.com'
+  email: 'billing@acme.com'
 });
 
 // Subscribe them to a plan
 await commet.subscriptions.create({
-  externalId: 'user_123',
+  customerId: 'cus_123',
   planCode: 'pro', // autocomplete works after `commet pull`
   billingInterval: 'yearly',
 });
@@ -86,14 +86,14 @@ const projects = await commet.quota.get({
 });
 
 // Check feature access
-const feature = await commet.features.get({
-  externalId: 'user_123',
+const access = await commet.featureAccess.canUse({
+  customerId: 'cus_123',
   code: 'api_calls'
 });
 
 // Generate customer portal link
 const portal = await commet.portal.getUrl({
-  externalId: 'user_123'
+  customerId: 'cus_123'
 });
 ```
 

--- a/packages/node/src/__tests__/resources-wire.test.ts
+++ b/packages/node/src/__tests__/resources-wire.test.ts
@@ -408,7 +408,7 @@ describe("Addons — consumptionModel enum + active listing", () => {
     await client().addons.listActive({ customerId: "cus_1" });
 
     const { url, init } = lastCall();
-    expect(url).toContain("/addons/active");
+    expect(url).toContain("/active-addons");
     expect(init.method).toBe("GET");
     expect(lastQuery().get("customerId")).toBe("cus_1");
   });
@@ -444,16 +444,19 @@ describe("Addons — consumptionModel enum + active listing", () => {
   });
 });
 
-describe("Features — canUse query injection + access parsing", () => {
+describe("FeatureAccess — canUse query injection + access parsing", () => {
   it("canUse() injects action=canUse into the query and puts code in the path", async () => {
     vi.mocked(fetch).mockResolvedValueOnce(
       jsonResponse({ success: true, data: { allowed: true } }),
     );
 
-    await client().features.canUse({ code: "api_calls", customerId: "cus_1" });
+    await client().featureAccess.canUse({
+      code: "api_calls",
+      customerId: "cus_1",
+    });
 
     const { url, init } = lastCall();
-    expect(url).toContain("/features/api_calls");
+    expect(url).toContain("/feature-access/api_calls");
     expect(init.method).toBe("GET");
     const q = lastQuery();
     expect(q.get("customerId")).toBe("cus_1");
@@ -467,7 +470,7 @@ describe("Features — canUse query injection + access parsing", () => {
       jsonResponse({ success: true, data: { allowed: false } }),
     );
 
-    await client().features.get({
+    await client().featureAccess.get({
       code: "api_calls",
       customerId: "cus_1",
       action: "check",
@@ -498,7 +501,7 @@ describe("Features — canUse query injection + access parsing", () => {
     );
 
     const data = unwrap(
-      await client().features.canUse({
+      await client().featureAccess.canUse({
         code: "api_calls",
         customerId: "cus_1",
       }),

--- a/packages/node/src/_generated_resources.ts
+++ b/packages/node/src/_generated_resources.ts
@@ -2,6 +2,7 @@ import { AddonsResource } from "./resources/addons";
 import { ApiKeysResource } from "./resources/api-keys";
 import { CreditPacksResource } from "./resources/credit-packs";
 import { CustomersResource } from "./resources/customers";
+import { FeatureAccessResource } from "./resources/feature-access";
 import { FeaturesResource } from "./resources/features";
 import { InvoicesResource } from "./resources/invoices";
 import { PayoutsResource } from "./resources/payouts";
@@ -21,6 +22,7 @@ export class GeneratedResources {
   public apiKeys!: ApiKeysResource;
   public creditPacks!: CreditPacksResource;
   public customers!: CustomersResource;
+  public featureAccess!: FeatureAccessResource;
   public features!: FeaturesResource;
   public invoices!: InvoicesResource;
   public payouts!: PayoutsResource;
@@ -39,6 +41,7 @@ export class GeneratedResources {
     this.apiKeys = new ApiKeysResource(http);
     this.creditPacks = new CreditPacksResource(http);
     this.customers = new CustomersResource(http);
+    this.featureAccess = new FeatureAccessResource(http);
     this.features = new FeaturesResource(http);
     this.invoices = new InvoicesResource(http);
     this.payouts = new PayoutsResource(http);

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -27,10 +27,13 @@ export type {
 } from "./resources/customers";
 export type {
   CanUseFeatureParams,
+  GetFeatureAccessParams,
+  ListFeatureAccessParams,
+} from "./resources/feature-access";
+export type {
   CreateFeatureParams,
   DeleteFeatureParams,
-  GetFeatureAccessParams,
-  ListFeaturesParams,
+  GetFeatureParams,
   UpdateFeatureParams,
 } from "./resources/features";
 export type {

--- a/packages/node/src/resources/addons.ts
+++ b/packages/node/src/resources/addons.ts
@@ -3,7 +3,7 @@ import type { ActiveAddon, Addon, DeletedObject } from "../types/models";
 import type { CommetHTTPClient } from "../utils/http";
 
 export interface ListActiveAddonsParams {
-  customerId?: string;
+  customerId: string;
 }
 
 export interface ListAddonsParams {
@@ -44,10 +44,10 @@ export class AddonsResource {
 
   /** List all active add-ons for a customer's subscription. */
   async listActive(
-    params?: ListActiveAddonsParams,
+    params: ListActiveAddonsParams,
     options?: RequestOptions,
   ): Promise<ApiResponse<Array<ActiveAddon>>> {
-    return this.httpClient.get("/addons/active", params, options);
+    return this.httpClient.get("/active-addons", params, options);
   }
 
   /** List all add-ons with cursor-based pagination. */

--- a/packages/node/src/resources/feature-access.ts
+++ b/packages/node/src/resources/feature-access.ts
@@ -1,0 +1,52 @@
+import type { ApiResponse, RequestOptions } from "../types/common";
+import type { FeatureAccess, FeatureLookup } from "../types/models";
+import type { CommetHTTPClient } from "../utils/http";
+
+export interface ListFeatureAccessParams {
+  customerId: string;
+}
+
+export interface GetFeatureAccessParams {
+  code: string;
+  customerId: string;
+  action?: string;
+}
+
+export interface CanUseFeatureParams {
+  code: string;
+  customerId: string;
+}
+
+export class FeatureAccessResource {
+  constructor(private httpClient: CommetHTTPClient) {}
+
+  /** List all features for a customer's active subscription, scoped by the customerId query parameter. */
+  async list(
+    params: ListFeatureAccessParams,
+    options?: RequestOptions,
+  ): Promise<ApiResponse<Array<FeatureAccess>>> {
+    return this.httpClient.get("/feature-access", params, options);
+  }
+
+  /** Get feature access details for a customer. Use action=canUse to check if the customer can consume one more unit. */
+  async get(
+    params: GetFeatureAccessParams,
+    options?: RequestOptions,
+  ): Promise<ApiResponse<FeatureLookup>> {
+    const { code, ...rest } = params;
+    return this.httpClient.get(`/feature-access/${code}`, rest, options);
+  }
+
+  /** Get feature access details for a customer. Use action=canUse to check if the customer can consume one more unit. */
+  async canUse(
+    params: CanUseFeatureParams,
+    options?: RequestOptions,
+  ): Promise<ApiResponse<FeatureLookup>> {
+    const { code, ...rest } = params;
+    return this.httpClient.get(
+      `/feature-access/${code}`,
+      { ...rest, action: "canUse" },
+      options,
+    );
+  }
+}

--- a/packages/node/src/resources/features.ts
+++ b/packages/node/src/resources/features.ts
@@ -1,26 +1,10 @@
 import type { ApiResponse, RequestOptions } from "../types/common";
 import type { FeatureType } from "../types/enums";
-import type {
-  DeletedObject,
-  Feature,
-  FeatureAccess,
-  FeatureLookup,
-} from "../types/models";
+import type { DeletedObject, Feature } from "../types/models";
 import type { CommetHTTPClient } from "../utils/http";
 
-export interface ListFeaturesParams {
-  customerId: string;
-}
-
-export interface GetFeatureAccessParams {
+export interface GetFeatureParams {
   code: string;
-  customerId: string;
-  action?: string;
-}
-
-export interface CanUseFeatureParams {
-  code: string;
-  customerId: string;
 }
 
 export interface CreateFeatureParams {
@@ -45,34 +29,18 @@ export interface DeleteFeatureParams {
 export class FeaturesResource {
   constructor(private httpClient: CommetHTTPClient) {}
 
-  /** List all features for a customer's active subscription. */
-  async list(
-    params: ListFeaturesParams,
-    options?: RequestOptions,
-  ): Promise<ApiResponse<Array<FeatureAccess>>> {
-    return this.httpClient.get("/features", params, options);
+  /** List every feature defined in the organization. This is the organization's feature catalog (definitions), not a customer's feature access. */
+  async list(): Promise<ApiResponse<Array<Feature>>> {
+    return this.httpClient.get("/features");
   }
 
-  /** Get feature access details. Use action=canUse to check if customer can consume one more unit. */
+  /** Get a single feature definition by code from the organization's feature catalog. */
   async get(
-    params: GetFeatureAccessParams,
+    params: GetFeatureParams,
     options?: RequestOptions,
-  ): Promise<ApiResponse<FeatureLookup>> {
-    const { code, ...rest } = params;
-    return this.httpClient.get(`/features/${code}`, rest, options);
-  }
-
-  /** Get feature access details. Use action=canUse to check if customer can consume one more unit. */
-  async canUse(
-    params: CanUseFeatureParams,
-    options?: RequestOptions,
-  ): Promise<ApiResponse<FeatureLookup>> {
-    const { code, ...rest } = params;
-    return this.httpClient.get(
-      `/features/${code}`,
-      { ...rest, action: "canUse" },
-      options,
-    );
+  ): Promise<ApiResponse<Feature>> {
+    const { code } = params;
+    return this.httpClient.get(`/features/${code}`, undefined, options);
   }
 
   /** Create a new feature. Code must be lowercase alphanumeric with underscores. */

--- a/packages/node/src/types/models.ts
+++ b/packages/node/src/types/models.ts
@@ -739,6 +739,14 @@ export interface Subscription {
     effectiveAt: string;
   } | null;
   cancelAtPeriodEnd: boolean;
+  scheduledPlanChange: {
+    changeType: "plan_downgrade" | "interval_change";
+    newPlanId: string | null;
+    newPlanName: string | null;
+    newBillingInterval: string | null;
+    /** @format date-time */
+    scheduledFor: string;
+  } | null;
   discount: {
     type: DiscountType;
     value: number;

--- a/packages/node/src/version.ts
+++ b/packages/node/src/version.ts
@@ -1,4 +1,4 @@
-export const API_VERSION = "2026-06-07";
+export const API_VERSION = "2026-06-10";
 
 declare const __SDK_VERSION__: string;
 export const SDK_VERSION: string = __SDK_VERSION__;


### PR DESCRIPTION
## Summary

Reconciles the SDK to the new flat API surface shipped at `commet-version: 2026-06-10` (platform PR commet-labs/commet-billing#1113). A feature's **catalog definition** and a customer's **access to it** are now distinct resources, mirroring the API.

- `commet.features.list()` / `commet.features.get({ code })` → org feature **catalog** (`Feature`), no `customerId`
- **New** `commet.featureAccess` resource → per-customer access: `list({ customerId })`, `get({ customerId, code })`, `canUse({ customerId, code })` (`FeatureAccess` / `FeatureLookup`)
- `commet.addons.listActive({ customerId })` now calls `GET /active-addons` (replaces `GET /addons/active`)
- `API_VERSION` pinned to `2026-06-10`

## Breaking changes (@commet/node major)

| Before (v6) | After (v7) |
|---|---|
| `features.list({ customerId })` → `FeatureAccess[]` | `features.list()` → `Feature[]` (catalog) |
| `features.get({ customerId, code })` → `FeatureLookup` | `features.get({ code })` → `Feature` (catalog item) |
| `features.canUse(...)` | `featureAccess.canUse({ customerId, code })` |
| — | `featureAccess.list/get` (new) |

Older SDK majors keep working unchanged: they pin their own `commet-version` header and the platform serves them the legacy variants.

## Consumers migrated in this PR

| Package | Change |
|---|---|
| `@commet/better-auth` | features plugin → `featureAccess.list/get/canUse` |
| `commet` (CLI) | new `feature-access` command group; `features` = catalog; pull/push on SDK reads |
| `examples/{fixed,metered,quota,seats}` | migrated to `featureAccess` |

## Release plan

Changesets included: `@commet/node` **major**, `@commet/better-auth` + `commet` minors. Merge → Version Packages PR → publish. Platform 2026-06-10 is already live in production (required before publish).

## Test plan

- [x] `turbo build/typecheck --filter='./packages/*' --force` → 5/5 packages green
- [x] 122 tests pass (node 107, next 15), including the rewired `resources-wire.test.ts`
- [x] All 7 examples build manually with real TypeScript checks (`balance-ai`/`credits` via `next build` directly — their `drizzle-kit push` prestep needs a live DB)