### PR TITLE
feat(next): support full webhook handler catalog

### DIFF
--- a/.changeset/commet-next-webhook-handler-retries.md
+++ b/.changeset/commet-next-webhook-handler-retries.md
@@ -1,0 +1,5 @@
+---
+"@commet/next": patch
+---
+
+Route all typed webhook callbacks and return a non-2xx response when handlers fail so failed deliveries can be retried.

--- a/.changeset/commet-next-webhook-handler-retries.md
+++ b/.changeset/commet-next-webhook-handler-retries.md
@@ -1,5 +1,5 @@
 ---
-"@commet/next": patch
+"@commet/next": minor
 ---
 
-Route all typed webhook callbacks and return a non-2xx response when handlers fail so failed deliveries can be retried.
+Add named webhook callbacks for the full typed Commet webhook catalog and return non-2xx responses when handlers fail so failed deliveries can be retried.

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -1,12 +1,49 @@
-import type { WebhookData, WebhookEvent, WebhookPayload } from "@commet/node";
+import type {
+  WebhookData,
+  WebhookEvent,
+  WebhookEventPayload,
+  WebhookPayload,
+} from "@commet/node";
 
 // Re-export types from @commet/node for convenience
-export type { WebhookData, WebhookEvent, WebhookPayload };
+export type { WebhookData, WebhookEvent, WebhookEventPayload, WebhookPayload };
+
+type PascalCaseEventSegment<S extends string> =
+  S extends `${infer Head}_${infer Tail}`
+    ? `${Capitalize<Head>}${PascalCaseEventSegment<Tail>}`
+    : Capitalize<S>;
+
+type PascalCaseEventName<S extends string> =
+  S extends `${infer Head}.${infer Tail}`
+    ? `${PascalCaseEventSegment<Head>}${PascalCaseEventName<Tail>}`
+    : PascalCaseEventSegment<S>;
+
+export type WebhookPayloadFor<E extends WebhookEvent> = Extract<
+  WebhookEventPayload,
+  { event: E }
+>;
+
+export type WebhookHandler<E extends WebhookEvent> = (
+  payload: WebhookPayloadFor<E>,
+) => Promise<void>;
+
+export type WebhookHandlerName<E extends WebhookEvent = WebhookEvent> =
+  `on${PascalCaseEventName<E>}`;
+
+/**
+ * Named callbacks for every Commet webhook event.
+ *
+ * Event names become callback names by removing dots/underscores and applying PascalCase:
+ * `payment_link.completed` -> `onPaymentLinkCompleted`.
+ */
+export type WebhookNamedHandlers = {
+  [E in WebhookEvent as WebhookHandlerName<E>]?: WebhookHandler<E>;
+};
 
 /**
  * Configuration for the Commet webhook handler
  */
-export interface WebhooksConfig {
+export interface WebhooksConfig extends WebhookNamedHandlers {
   /**
    * Webhook secret from your Commet dashboard
    * Used to verify webhook signatures
@@ -30,7 +67,7 @@ export interface WebhooksConfig {
    * }
    * ```
    */
-  onSubscriptionActivated?: (payload: WebhookPayload) => Promise<void>;
+  onSubscriptionActivated?: WebhookHandler<"subscription.activated">;
 
   /**
    * Handles the `subscription.canceled` webhook event
@@ -49,7 +86,7 @@ export interface WebhooksConfig {
    * }
    * ```
    */
-  onSubscriptionCanceled?: (payload: WebhookPayload) => Promise<void>;
+  onSubscriptionCanceled?: WebhookHandler<"subscription.canceled">;
 
   /**
    * Handles the `subscription.created` webhook event
@@ -66,7 +103,7 @@ export interface WebhooksConfig {
    * }
    * ```
    */
-  onSubscriptionCreated?: (payload: WebhookPayload) => Promise<void>;
+  onSubscriptionCreated?: WebhookHandler<"subscription.created">;
 
   /**
    * Handles the `subscription.updated` webhook event
@@ -85,7 +122,7 @@ export interface WebhooksConfig {
    * }
    * ```
    */
-  onSubscriptionUpdated?: (payload: WebhookPayload) => Promise<void>;
+  onSubscriptionUpdated?: WebhookHandler<"subscription.updated">;
 
   /**
    * Handles the `subscription.plan_changed` webhook event
@@ -104,14 +141,14 @@ export interface WebhooksConfig {
    * }
    * ```
    */
-  onSubscriptionPlanChanged?: (payload: WebhookPayload) => Promise<void>;
+  onSubscriptionPlanChanged?: WebhookHandler<"subscription.plan_changed">;
 
   /**
    * Handles the `customer.state_changed` webhook event
    *
    * Fired whenever a customer's billing state snapshot changes.
    */
-  onCustomerStateChanged?: (payload: WebhookPayload) => Promise<void>;
+  onCustomerStateChanged?: WebhookHandler<"customer.state_changed">;
 
   /**
    * Handles the `payment.received` webhook event
@@ -120,14 +157,14 @@ export interface WebhooksConfig {
    *
    * @param payload - The webhook payload containing payment data
    */
-  onPaymentReceived?: (payload: WebhookPayload) => Promise<void>;
+  onPaymentReceived?: WebhookHandler<"payment.received">;
 
   /**
    * Handles the `payment.recovered` webhook event
    *
    * Fired when a previously failed payment succeeds.
    */
-  onPaymentRecovered?: (payload: WebhookPayload) => Promise<void>;
+  onPaymentRecovered?: WebhookHandler<"payment.recovered">;
 
   /**
    * Handles the `payment.failed` webhook event
@@ -137,14 +174,14 @@ export interface WebhooksConfig {
    *
    * @param payload - The webhook payload containing payment data
    */
-  onPaymentFailed?: (payload: WebhookPayload) => Promise<void>;
+  onPaymentFailed?: WebhookHandler<"payment.failed">;
 
   /**
    * Handles the `usage.recorded` webhook event
    *
    * Fired after usage is recorded for a customer feature.
    */
-  onUsageRecorded?: (payload: WebhookPayload) => Promise<void>;
+  onUsageRecorded?: WebhookHandler<"usage.recorded">;
 
   /**
    * Handles the `invoice.created` webhook event
@@ -153,7 +190,7 @@ export interface WebhooksConfig {
    *
    * @param payload - The webhook payload containing invoice data
    */
-  onInvoiceCreated?: (payload: WebhookPayload) => Promise<void>;
+  onInvoiceCreated?: WebhookHandler<"invoice.created">;
 
   /**
    * Catch-all handler that receives all webhook events
@@ -171,7 +208,7 @@ export interface WebhooksConfig {
    * }
    * ```
    */
-  onPayload?: (payload: WebhookPayload) => Promise<void>;
+  onPayload?: (payload: WebhookEventPayload) => Promise<void>;
 
   /**
    * Error handler for webhook processing failures

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -107,6 +107,13 @@ export interface WebhooksConfig {
   onSubscriptionPlanChanged?: (payload: WebhookPayload) => Promise<void>;
 
   /**
+   * Handles the `customer.state_changed` webhook event
+   *
+   * Fired whenever a customer's billing state snapshot changes.
+   */
+  onCustomerStateChanged?: (payload: WebhookPayload) => Promise<void>;
+
+  /**
    * Handles the `payment.received` webhook event
    *
    * Fired when a payment is successfully processed for a subscription.
@@ -114,6 +121,13 @@ export interface WebhooksConfig {
    * @param payload - The webhook payload containing payment data
    */
   onPaymentReceived?: (payload: WebhookPayload) => Promise<void>;
+
+  /**
+   * Handles the `payment.recovered` webhook event
+   *
+   * Fired when a previously failed payment succeeds.
+   */
+  onPaymentRecovered?: (payload: WebhookPayload) => Promise<void>;
 
   /**
    * Handles the `payment.failed` webhook event
@@ -124,6 +138,13 @@ export interface WebhooksConfig {
    * @param payload - The webhook payload containing payment data
    */
   onPaymentFailed?: (payload: WebhookPayload) => Promise<void>;
+
+  /**
+   * Handles the `usage.recorded` webhook event
+   *
+   * Fired after usage is recorded for a customer feature.
+   */
+  onUsageRecorded?: (payload: WebhookPayload) => Promise<void>;
 
   /**
    * Handles the `invoice.created` webhook event

--- a/packages/next/src/webhooks.test.ts
+++ b/packages/next/src/webhooks.test.ts
@@ -215,6 +215,81 @@ describe("Webhooks", () => {
       expect(mockHandler).toHaveBeenCalledWith(payload);
     });
 
+    it("should route customer.state_changed events", async () => {
+      const mockHandler = vi.fn().mockResolvedValue(undefined);
+      const webhookHandler = Webhooks({
+        webhookSecret: "secret_123",
+        onCustomerStateChanged: mockHandler,
+      });
+
+      const payload = {
+        event: "customer.state_changed",
+        timestamp: "2024-01-01T00:00:00Z",
+        organizationId: "org_123",
+        data: { customerId: "cus_123" },
+      };
+
+      const request = new NextRequest("https://example.com/webhooks", {
+        method: "POST",
+        body: JSON.stringify(payload),
+        headers: { "x-commet-signature": "sig" },
+      });
+
+      await webhookHandler(request);
+
+      expect(mockHandler).toHaveBeenCalledWith(payload);
+    });
+
+    it("should route payment.recovered events", async () => {
+      const mockHandler = vi.fn().mockResolvedValue(undefined);
+      const webhookHandler = Webhooks({
+        webhookSecret: "secret_123",
+        onPaymentRecovered: mockHandler,
+      });
+
+      const payload = {
+        event: "payment.recovered",
+        timestamp: "2024-01-01T00:00:00Z",
+        organizationId: "org_123",
+        data: { paymentId: "pay_123" },
+      };
+
+      const request = new NextRequest("https://example.com/webhooks", {
+        method: "POST",
+        body: JSON.stringify(payload),
+        headers: { "x-commet-signature": "sig" },
+      });
+
+      await webhookHandler(request);
+
+      expect(mockHandler).toHaveBeenCalledWith(payload);
+    });
+
+    it("should route usage.recorded events", async () => {
+      const mockHandler = vi.fn().mockResolvedValue(undefined);
+      const webhookHandler = Webhooks({
+        webhookSecret: "secret_123",
+        onUsageRecorded: mockHandler,
+      });
+
+      const payload = {
+        event: "usage.recorded",
+        timestamp: "2024-01-01T00:00:00Z",
+        organizationId: "org_123",
+        data: { customerId: "cus_123", featureCode: "api_calls", value: 1 },
+      };
+
+      const request = new NextRequest("https://example.com/webhooks", {
+        method: "POST",
+        body: JSON.stringify(payload),
+        headers: { "x-commet-signature": "sig" },
+      });
+
+      await webhookHandler(request);
+
+      expect(mockHandler).toHaveBeenCalledWith(payload);
+    });
+
     it("should not call handler for unregistered events", async () => {
       const activatedHandler = vi.fn().mockResolvedValue(undefined);
       const webhookHandler = Webhooks({
@@ -352,13 +427,12 @@ describe("Webhooks", () => {
       const response = await webhookHandler(request);
       const data = (await response.json()) as {
         received: boolean;
-        warning?: string;
+        error?: string;
       };
 
-      // Should still return 200 to prevent retries
-      expect(response.status).toBe(200);
-      expect(data.received).toBe(true);
-      expect(data.warning).toBe("Handler failed");
+      expect(response.status).toBe(500);
+      expect(data.received).toBe(false);
+      expect(data.error).toBe("Handler failed");
       expect(onError).toHaveBeenCalledWith(handlerError, payload);
     });
 
@@ -385,7 +459,7 @@ describe("Webhooks", () => {
 
       const response = await webhookHandler(request);
 
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(500);
     });
   });
 

--- a/packages/next/src/webhooks.test.ts
+++ b/packages/next/src/webhooks.test.ts
@@ -1,12 +1,276 @@
-import { Webhooks as CommetWebhooks } from "@commet/node";
+import {
+  Webhooks as CommetWebhooks,
+  type WebhookEvent,
+  type WebhookEventPayload,
+} from "@commet/node";
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WebhookHandlerName, WebhooksConfig } from "./types";
 import { Webhooks } from "./webhooks";
 
 // Mock @commet/node
 vi.mock("@commet/node", () => ({
   Webhooks: vi.fn(),
 }));
+
+const webhookHandlerCases = [
+  {
+    event: "subscription.created",
+    handlerName: "onSubscriptionCreated",
+  },
+  {
+    event: "subscription.activated",
+    handlerName: "onSubscriptionActivated",
+  },
+  {
+    event: "subscription.reactivated",
+    handlerName: "onSubscriptionReactivated",
+  },
+  {
+    event: "subscription.canceled",
+    handlerName: "onSubscriptionCanceled",
+  },
+  {
+    event: "subscription.updated",
+    handlerName: "onSubscriptionUpdated",
+  },
+  {
+    event: "subscription.plan_changed",
+    handlerName: "onSubscriptionPlanChanged",
+  },
+  {
+    event: "subscription.cancellation_scheduled",
+    handlerName: "onSubscriptionCancellationScheduled",
+  },
+  {
+    event: "subscription.cancellation_revoked",
+    handlerName: "onSubscriptionCancellationRevoked",
+  },
+  {
+    event: "subscription.plan_change_scheduled",
+    handlerName: "onSubscriptionPlanChangeScheduled",
+  },
+  {
+    event: "subscription.plan_change_revoked",
+    handlerName: "onSubscriptionPlanChangeRevoked",
+  },
+  {
+    event: "subscription.past_due",
+    handlerName: "onSubscriptionPastDue",
+  },
+  {
+    event: "trial.started",
+    handlerName: "onTrialStarted",
+  },
+  {
+    event: "trial.converted",
+    handlerName: "onTrialConverted",
+  },
+  {
+    event: "trial.expired",
+    handlerName: "onTrialExpired",
+  },
+  {
+    event: "trial.will_end",
+    handlerName: "onTrialWillEnd",
+  },
+  {
+    event: "trial.checkout_ready",
+    handlerName: "onTrialCheckoutReady",
+  },
+  {
+    event: "checkout.ready",
+    handlerName: "onCheckoutReady",
+  },
+  {
+    event: "payment.received",
+    handlerName: "onPaymentReceived",
+  },
+  {
+    event: "payment.failed",
+    handlerName: "onPaymentFailed",
+  },
+  {
+    event: "payment.recovered",
+    handlerName: "onPaymentRecovered",
+  },
+  {
+    event: "payment.retry_failed",
+    handlerName: "onPaymentRetryFailed",
+  },
+  {
+    event: "payment.refunded",
+    handlerName: "onPaymentRefunded",
+  },
+  {
+    event: "payment.disputed",
+    handlerName: "onPaymentDisputed",
+  },
+  {
+    event: "payment.dispute_resolved",
+    handlerName: "onPaymentDisputeResolved",
+  },
+  {
+    event: "payment_link.created",
+    handlerName: "onPaymentLinkCreated",
+  },
+  {
+    event: "payment_link.completed",
+    handlerName: "onPaymentLinkCompleted",
+  },
+  {
+    event: "payment_link.failed",
+    handlerName: "onPaymentLinkFailed",
+  },
+  {
+    event: "payment_link.canceled",
+    handlerName: "onPaymentLinkCanceled",
+  },
+  {
+    event: "invoice.created",
+    handlerName: "onInvoiceCreated",
+  },
+  {
+    event: "invoice.upcoming",
+    handlerName: "onInvoiceUpcoming",
+  },
+  {
+    event: "invoice.overdue",
+    handlerName: "onInvoiceOverdue",
+  },
+  {
+    event: "invoice.voided",
+    handlerName: "onInvoiceVoided",
+  },
+  {
+    event: "payment_method.attached",
+    handlerName: "onPaymentMethodAttached",
+  },
+  {
+    event: "payment_method.updated",
+    handlerName: "onPaymentMethodUpdated",
+  },
+  {
+    event: "customer.created",
+    handlerName: "onCustomerCreated",
+  },
+  {
+    event: "customer.updated",
+    handlerName: "onCustomerUpdated",
+  },
+  {
+    event: "customer.state_changed",
+    handlerName: "onCustomerStateChanged",
+  },
+  {
+    event: "credits.granted",
+    handlerName: "onCreditsGranted",
+  },
+  {
+    event: "credits.purchased",
+    handlerName: "onCreditsPurchased",
+  },
+  {
+    event: "credits.low",
+    handlerName: "onCreditsLow",
+  },
+  {
+    event: "credits.depleted",
+    handlerName: "onCreditsDepleted",
+  },
+  {
+    event: "credits.expired",
+    handlerName: "onCreditsExpired",
+  },
+  {
+    event: "balance.topped_up",
+    handlerName: "onBalanceToppedUp",
+  },
+  {
+    event: "balance.low",
+    handlerName: "onBalanceLow",
+  },
+  {
+    event: "balance.depleted",
+    handlerName: "onBalanceDepleted",
+  },
+  {
+    event: "quota.threshold_reached",
+    handlerName: "onQuotaThresholdReached",
+  },
+  {
+    event: "quota.exceeded",
+    handlerName: "onQuotaExceeded",
+  },
+  {
+    event: "usage.recorded",
+    handlerName: "onUsageRecorded",
+  },
+  {
+    event: "seats.updated",
+    handlerName: "onSeatsUpdated",
+  },
+  {
+    event: "seats.limit_reached",
+    handlerName: "onSeatsLimitReached",
+  },
+  {
+    event: "addon.activated",
+    handlerName: "onAddonActivated",
+  },
+  {
+    event: "addon.deactivated",
+    handlerName: "onAddonDeactivated",
+  },
+  {
+    event: "payout.available",
+    handlerName: "onPayoutAvailable",
+  },
+  {
+    event: "payout.created",
+    handlerName: "onPayoutCreated",
+  },
+  {
+    event: "payout.paid",
+    handlerName: "onPayoutPaid",
+  },
+  {
+    event: "payout.failed",
+    handlerName: "onPayoutFailed",
+  },
+] as const satisfies readonly {
+  event: WebhookEvent;
+  handlerName: WebhookHandlerName;
+}[];
+
+type CoveredWebhookEvent = (typeof webhookHandlerCases)[number]["event"];
+type MissingWebhookEvent = Exclude<WebhookEvent, CoveredWebhookEvent>;
+type ExtraWebhookEvent = Exclude<CoveredWebhookEvent, WebhookEvent>;
+type ConfigNamedWebhookHandlerName = Exclude<
+  Extract<keyof WebhooksConfig, `on${string}`>,
+  "onError" | "onPayload"
+>;
+type MissingWebhookHandlerName = Exclude<
+  WebhookHandlerName,
+  ConfigNamedWebhookHandlerName
+>;
+type ExtraWebhookHandlerName = Exclude<
+  ConfigNamedWebhookHandlerName,
+  WebhookHandlerName
+>;
+
+const webhookEventCoverage: [MissingWebhookEvent, ExtraWebhookEvent] extends [
+  never,
+  never,
+]
+  ? true
+  : never = true;
+const webhookHandlerCoverage: [
+  MissingWebhookHandlerName,
+  ExtraWebhookHandlerName,
+] extends [never, never]
+  ? true
+  : never = true;
 
 const mockCommetWebhooks = vi.mocked(CommetWebhooks);
 
@@ -18,6 +282,25 @@ function webhooksMock(verifyResult: boolean) {
       verify: vi.fn().mockReturnValue(verifyResult),
     } as unknown as InstanceType<typeof CommetWebhooks>;
   };
+}
+
+function createPayload(event: WebhookEvent): WebhookEventPayload {
+  return {
+    event,
+    timestamp: "2024-01-01T00:00:00Z",
+    organizationId: "org_123",
+    mode: "sandbox",
+    apiVersion: "2026-06-10",
+    data: {},
+  } as WebhookEventPayload;
+}
+
+function createRequest(payload: WebhookEventPayload | Record<string, unknown>) {
+  return new NextRequest("https://example.com/webhooks", {
+    method: "POST",
+    body: JSON.stringify(payload),
+    headers: { "x-commet-signature": "sig" },
+  });
 }
 
 describe("Webhooks", () => {
@@ -34,27 +317,9 @@ describe("Webhooks", () => {
         webhookSecret: "secret_123",
         onSubscriptionActivated: mockHandler,
       });
+      const payload = createPayload("subscription.activated");
 
-      const payload = {
-        event: "subscription.activated",
-        timestamp: "2024-01-01T00:00:00Z",
-        organizationId: "org_123",
-        data: {
-          subscriptionId: "sub_123",
-          customerId: "cus_123",
-          status: "active",
-        },
-      };
-
-      const request = new NextRequest("https://example.com/webhooks", {
-        method: "POST",
-        body: JSON.stringify(payload),
-        headers: {
-          "x-commet-signature": "valid_signature",
-        },
-      });
-
-      const response = await webhookHandler(request);
+      const response = await webhookHandler(createRequest(payload));
       const data = (await response.json()) as { received: boolean };
 
       expect(response.status).toBe(200);
@@ -74,7 +339,7 @@ describe("Webhooks", () => {
 
       const request = new NextRequest("https://example.com/webhooks", {
         method: "POST",
-        body: JSON.stringify({ event: "subscription.activated" }),
+        body: JSON.stringify(createPayload("subscription.activated")),
         headers: {
           "x-commet-signature": "invalid_signature",
         },
@@ -102,7 +367,7 @@ describe("Webhooks", () => {
 
       const request = new NextRequest("https://example.com/webhooks", {
         method: "POST",
-        body: JSON.stringify({ event: "subscription.activated" }),
+        body: JSON.stringify(createPayload("subscription.activated")),
       });
 
       const response = await webhookHandler(request);
@@ -114,180 +379,33 @@ describe("Webhooks", () => {
   });
 
   describe("event routing", () => {
-    it("should route subscription.activated events", async () => {
+    it("should cover every typed webhook event and named handler", () => {
+      expect(webhookHandlerCases).toHaveLength(56);
+      expect(new Set(webhookHandlerCases.map(({ event }) => event)).size).toBe(
+        56,
+      );
+      expect(webhookEventCoverage).toBe(true);
+      expect(webhookHandlerCoverage).toBe(true);
+    });
+
+    it.each(
+      webhookHandlerCases,
+    )("should route $event events to $handlerName", async ({
+      event,
+      handlerName,
+    }) => {
       const mockHandler = vi.fn().mockResolvedValue(undefined);
       const webhookHandler = Webhooks({
         webhookSecret: "secret_123",
-        onSubscriptionActivated: mockHandler,
-      });
+        [handlerName]: mockHandler,
+      } as WebhooksConfig);
+      const payload = createPayload(event);
 
-      const payload = {
-        event: "subscription.activated",
-        timestamp: "2024-01-01T00:00:00Z",
-        organizationId: "org_123",
-        data: { subscriptionId: "sub_123" },
-      };
+      const response = await webhookHandler(createRequest(payload));
 
-      const request = new NextRequest("https://example.com/webhooks", {
-        method: "POST",
-        body: JSON.stringify(payload),
-        headers: { "x-commet-signature": "sig" },
-      });
-
-      await webhookHandler(request);
-
+      expect(response.status).toBe(200);
       expect(mockHandler).toHaveBeenCalledWith(payload);
       expect(mockHandler).toHaveBeenCalledTimes(1);
-    });
-
-    it("should route subscription.canceled events", async () => {
-      const mockHandler = vi.fn().mockResolvedValue(undefined);
-      const webhookHandler = Webhooks({
-        webhookSecret: "secret_123",
-        onSubscriptionCanceled: mockHandler,
-      });
-
-      const payload = {
-        event: "subscription.canceled",
-        timestamp: "2024-01-01T00:00:00Z",
-        organizationId: "org_123",
-        data: { subscriptionId: "sub_123" },
-      };
-
-      const request = new NextRequest("https://example.com/webhooks", {
-        method: "POST",
-        body: JSON.stringify(payload),
-        headers: { "x-commet-signature": "sig" },
-      });
-
-      await webhookHandler(request);
-
-      expect(mockHandler).toHaveBeenCalledWith(payload);
-    });
-
-    it("should route subscription.created events", async () => {
-      const mockHandler = vi.fn().mockResolvedValue(undefined);
-      const webhookHandler = Webhooks({
-        webhookSecret: "secret_123",
-        onSubscriptionCreated: mockHandler,
-      });
-
-      const payload = {
-        event: "subscription.created",
-        timestamp: "2024-01-01T00:00:00Z",
-        organizationId: "org_123",
-        data: { subscriptionId: "sub_123" },
-      };
-
-      const request = new NextRequest("https://example.com/webhooks", {
-        method: "POST",
-        body: JSON.stringify(payload),
-        headers: { "x-commet-signature": "sig" },
-      });
-
-      await webhookHandler(request);
-
-      expect(mockHandler).toHaveBeenCalledWith(payload);
-    });
-
-    it("should route subscription.updated events", async () => {
-      const mockHandler = vi.fn().mockResolvedValue(undefined);
-      const webhookHandler = Webhooks({
-        webhookSecret: "secret_123",
-        onSubscriptionUpdated: mockHandler,
-      });
-
-      const payload = {
-        event: "subscription.updated",
-        timestamp: "2024-01-01T00:00:00Z",
-        organizationId: "org_123",
-        data: { subscriptionId: "sub_123" },
-      };
-
-      const request = new NextRequest("https://example.com/webhooks", {
-        method: "POST",
-        body: JSON.stringify(payload),
-        headers: { "x-commet-signature": "sig" },
-      });
-
-      await webhookHandler(request);
-
-      expect(mockHandler).toHaveBeenCalledWith(payload);
-    });
-
-    it("should route customer.state_changed events", async () => {
-      const mockHandler = vi.fn().mockResolvedValue(undefined);
-      const webhookHandler = Webhooks({
-        webhookSecret: "secret_123",
-        onCustomerStateChanged: mockHandler,
-      });
-
-      const payload = {
-        event: "customer.state_changed",
-        timestamp: "2024-01-01T00:00:00Z",
-        organizationId: "org_123",
-        data: { customerId: "cus_123" },
-      };
-
-      const request = new NextRequest("https://example.com/webhooks", {
-        method: "POST",
-        body: JSON.stringify(payload),
-        headers: { "x-commet-signature": "sig" },
-      });
-
-      await webhookHandler(request);
-
-      expect(mockHandler).toHaveBeenCalledWith(payload);
-    });
-
-    it("should route payment.recovered events", async () => {
-      const mockHandler = vi.fn().mockResolvedValue(undefined);
-      const webhookHandler = Webhooks({
-        webhookSecret: "secret_123",
-        onPaymentRecovered: mockHandler,
-      });
-
-      const payload = {
-        event: "payment.recovered",
-        timestamp: "2024-01-01T00:00:00Z",
-        organizationId: "org_123",
-        data: { paymentId: "pay_123" },
-      };
-
-      const request = new NextRequest("https://example.com/webhooks", {
-        method: "POST",
-        body: JSON.stringify(payload),
-        headers: { "x-commet-signature": "sig" },
-      });
-
-      await webhookHandler(request);
-
-      expect(mockHandler).toHaveBeenCalledWith(payload);
-    });
-
-    it("should route usage.recorded events", async () => {
-      const mockHandler = vi.fn().mockResolvedValue(undefined);
-      const webhookHandler = Webhooks({
-        webhookSecret: "secret_123",
-        onUsageRecorded: mockHandler,
-      });
-
-      const payload = {
-        event: "usage.recorded",
-        timestamp: "2024-01-01T00:00:00Z",
-        organizationId: "org_123",
-        data: { customerId: "cus_123", featureCode: "api_calls", value: 1 },
-      };
-
-      const request = new NextRequest("https://example.com/webhooks", {
-        method: "POST",
-        body: JSON.stringify(payload),
-        headers: { "x-commet-signature": "sig" },
-      });
-
-      await webhookHandler(request);
-
-      expect(mockHandler).toHaveBeenCalledWith(payload);
     });
 
     it("should not call handler for unregistered events", async () => {
@@ -296,21 +414,9 @@ describe("Webhooks", () => {
         webhookSecret: "secret_123",
         onSubscriptionActivated: activatedHandler,
       });
+      const payload = createPayload("subscription.canceled");
 
-      const payload = {
-        event: "subscription.canceled",
-        timestamp: "2024-01-01T00:00:00Z",
-        organizationId: "org_123",
-        data: { subscriptionId: "sub_123" },
-      };
-
-      const request = new NextRequest("https://example.com/webhooks", {
-        method: "POST",
-        body: JSON.stringify(payload),
-        headers: { "x-commet-signature": "sig" },
-      });
-
-      const response = await webhookHandler(request);
+      const response = await webhookHandler(createRequest(payload));
 
       expect(response.status).toBe(200);
       expect(activatedHandler).not.toHaveBeenCalled();
@@ -327,21 +433,9 @@ describe("Webhooks", () => {
         onPayload,
         onSubscriptionActivated: specificHandler,
       });
+      const payload = createPayload("subscription.activated");
 
-      const payload = {
-        event: "subscription.activated",
-        timestamp: "2024-01-01T00:00:00Z",
-        organizationId: "org_123",
-        data: { subscriptionId: "sub_123" },
-      };
-
-      const request = new NextRequest("https://example.com/webhooks", {
-        method: "POST",
-        body: JSON.stringify(payload),
-        headers: { "x-commet-signature": "sig" },
-      });
-
-      await webhookHandler(request);
+      await webhookHandler(createRequest(payload));
 
       expect(onPayload).toHaveBeenCalledWith(payload);
       expect(specificHandler).toHaveBeenCalledWith(payload);
@@ -354,21 +448,9 @@ describe("Webhooks", () => {
         webhookSecret: "secret_123",
         onPayload,
       });
+      const payload = createPayload("subscription.created");
 
-      const payload = {
-        event: "subscription.created",
-        timestamp: "2024-01-01T00:00:00Z",
-        organizationId: "org_123",
-        data: { subscriptionId: "sub_123" },
-      };
-
-      const request = new NextRequest("https://example.com/webhooks", {
-        method: "POST",
-        body: JSON.stringify(payload),
-        headers: { "x-commet-signature": "sig" },
-      });
-
-      await webhookHandler(request);
+      await webhookHandler(createRequest(payload));
 
       expect(onPayload).toHaveBeenCalledWith(payload);
     });
@@ -410,21 +492,9 @@ describe("Webhooks", () => {
         onSubscriptionActivated: mockHandler,
         onError,
       });
+      const payload = createPayload("subscription.activated");
 
-      const payload = {
-        event: "subscription.activated",
-        timestamp: "2024-01-01T00:00:00Z",
-        organizationId: "org_123",
-        data: { subscriptionId: "sub_123" },
-      };
-
-      const request = new NextRequest("https://example.com/webhooks", {
-        method: "POST",
-        body: JSON.stringify(payload),
-        headers: { "x-commet-signature": "sig" },
-      });
-
-      const response = await webhookHandler(request);
+      const response = await webhookHandler(createRequest(payload));
       const data = (await response.json()) as {
         received: boolean;
         error?: string;
@@ -443,21 +513,9 @@ describe("Webhooks", () => {
         webhookSecret: "secret_123",
         onSubscriptionActivated: mockHandler,
       });
+      const payload = createPayload("subscription.activated");
 
-      const payload = {
-        event: "subscription.activated",
-        timestamp: "2024-01-01T00:00:00Z",
-        organizationId: "org_123",
-        data: { subscriptionId: "sub_123" },
-      };
-
-      const request = new NextRequest("https://example.com/webhooks", {
-        method: "POST",
-        body: JSON.stringify(payload),
-        headers: { "x-commet-signature": "sig" },
-      });
-
-      const response = await webhookHandler(request);
+      const response = await webhookHandler(createRequest(payload));
 
       expect(response.status).toBe(500);
     });
@@ -484,21 +542,9 @@ describe("Webhooks", () => {
         onPayload,
         onSubscriptionActivated: specificHandler,
       });
+      const payload = createPayload("subscription.activated");
 
-      const payload = {
-        event: "subscription.activated",
-        timestamp: "2024-01-01T00:00:00Z",
-        organizationId: "org_123",
-        data: { subscriptionId: "sub_123" },
-      };
-
-      const request = new NextRequest("https://example.com/webhooks", {
-        method: "POST",
-        body: JSON.stringify(payload),
-        headers: { "x-commet-signature": "sig" },
-      });
-
-      await webhookHandler(request);
+      await webhookHandler(createRequest(payload));
 
       expect(onPayload).toHaveBeenCalled();
       expect(specificHandler).toHaveBeenCalled();
@@ -517,21 +563,9 @@ describe("Webhooks", () => {
       const webhookHandler = Webhooks({
         webhookSecret: "secret_123",
       });
+      const payload = createPayload("subscription.activated");
 
-      const payload = {
-        event: "subscription.activated",
-        timestamp: "2024-01-01T00:00:00Z",
-        organizationId: "org_123",
-        data: { subscriptionId: "sub_123" },
-      };
-
-      const request = new NextRequest("https://example.com/webhooks", {
-        method: "POST",
-        body: JSON.stringify(payload),
-        headers: { "x-commet-signature": "sig" },
-      });
-
-      const response = await webhookHandler(request);
+      const response = await webhookHandler(createRequest(payload));
       const data = (await response.json()) as { received: boolean };
 
       expect(response.status).toBe(200);

--- a/packages/next/src/webhooks.ts
+++ b/packages/next/src/webhooks.ts
@@ -1,7 +1,68 @@
-import type { WebhookPayload } from "@commet/node";
+import type { WebhookEvent, WebhookEventPayload } from "@commet/node";
 import { Webhooks as CommetWebhooks } from "@commet/node";
 import { type NextRequest, NextResponse } from "next/server";
-import type { WebhooksConfig } from "./types";
+import type { WebhookHandlerName, WebhooksConfig } from "./types";
+
+const webhookEventHandlerNames = {
+  "subscription.created": "onSubscriptionCreated",
+  "subscription.activated": "onSubscriptionActivated",
+  "subscription.reactivated": "onSubscriptionReactivated",
+  "subscription.canceled": "onSubscriptionCanceled",
+  "subscription.updated": "onSubscriptionUpdated",
+  "subscription.plan_changed": "onSubscriptionPlanChanged",
+  "subscription.cancellation_scheduled": "onSubscriptionCancellationScheduled",
+  "subscription.cancellation_revoked": "onSubscriptionCancellationRevoked",
+  "subscription.plan_change_scheduled": "onSubscriptionPlanChangeScheduled",
+  "subscription.plan_change_revoked": "onSubscriptionPlanChangeRevoked",
+  "subscription.past_due": "onSubscriptionPastDue",
+  "trial.started": "onTrialStarted",
+  "trial.converted": "onTrialConverted",
+  "trial.expired": "onTrialExpired",
+  "trial.will_end": "onTrialWillEnd",
+  "trial.checkout_ready": "onTrialCheckoutReady",
+  "checkout.ready": "onCheckoutReady",
+  "payment.received": "onPaymentReceived",
+  "payment.failed": "onPaymentFailed",
+  "payment.recovered": "onPaymentRecovered",
+  "payment.retry_failed": "onPaymentRetryFailed",
+  "payment.refunded": "onPaymentRefunded",
+  "payment.disputed": "onPaymentDisputed",
+  "payment.dispute_resolved": "onPaymentDisputeResolved",
+  "payment_link.created": "onPaymentLinkCreated",
+  "payment_link.completed": "onPaymentLinkCompleted",
+  "payment_link.failed": "onPaymentLinkFailed",
+  "payment_link.canceled": "onPaymentLinkCanceled",
+  "invoice.created": "onInvoiceCreated",
+  "invoice.upcoming": "onInvoiceUpcoming",
+  "invoice.overdue": "onInvoiceOverdue",
+  "invoice.voided": "onInvoiceVoided",
+  "payment_method.attached": "onPaymentMethodAttached",
+  "payment_method.updated": "onPaymentMethodUpdated",
+  "customer.created": "onCustomerCreated",
+  "customer.updated": "onCustomerUpdated",
+  "customer.state_changed": "onCustomerStateChanged",
+  "credits.granted": "onCreditsGranted",
+  "credits.purchased": "onCreditsPurchased",
+  "credits.low": "onCreditsLow",
+  "credits.depleted": "onCreditsDepleted",
+  "credits.expired": "onCreditsExpired",
+  "balance.topped_up": "onBalanceToppedUp",
+  "balance.low": "onBalanceLow",
+  "balance.depleted": "onBalanceDepleted",
+  "quota.threshold_reached": "onQuotaThresholdReached",
+  "quota.exceeded": "onQuotaExceeded",
+  "usage.recorded": "onUsageRecorded",
+  "seats.updated": "onSeatsUpdated",
+  "seats.limit_reached": "onSeatsLimitReached",
+  "addon.activated": "onAddonActivated",
+  "addon.deactivated": "onAddonDeactivated",
+  "payout.available": "onPayoutAvailable",
+  "payout.created": "onPayoutCreated",
+  "payout.paid": "onPayoutPaid",
+  "payout.failed": "onPayoutFailed",
+} as const satisfies Record<WebhookEvent, WebhookHandlerName>;
+
+type RuntimeWebhookHandler = (payload: WebhookEventPayload) => Promise<void>;
 
 /**
  * Create a Next.js webhook handler for Commet events
@@ -28,22 +89,7 @@ import type { WebhooksConfig } from "./types";
  * ```
  */
 export const Webhooks = (config: WebhooksConfig) => {
-  const {
-    webhookSecret,
-    onSubscriptionActivated,
-    onSubscriptionCanceled,
-    onSubscriptionCreated,
-    onSubscriptionUpdated,
-    onSubscriptionPlanChanged,
-    onCustomerStateChanged,
-    onPaymentReceived,
-    onPaymentRecovered,
-    onPaymentFailed,
-    onUsageRecorded,
-    onInvoiceCreated,
-    onPayload,
-    onError,
-  } = config;
+  const { webhookSecret, onPayload, onError } = config;
 
   const webhooks = new CommetWebhooks();
 
@@ -66,9 +112,9 @@ export const Webhooks = (config: WebhooksConfig) => {
         );
       }
 
-      let payload: WebhookPayload;
+      let payload: WebhookEventPayload;
       try {
-        payload = JSON.parse(rawBody) as WebhookPayload;
+        payload = JSON.parse(rawBody) as WebhookEventPayload;
       } catch (parseError) {
         console.error("[Commet Webhook] Failed to parse payload:", parseError);
         if (onError) {
@@ -91,75 +137,10 @@ export const Webhooks = (config: WebhooksConfig) => {
         promises.push(onPayload(payload));
       }
 
-      switch (payload.event) {
-        case "subscription.activated":
-          if (onSubscriptionActivated) {
-            promises.push(onSubscriptionActivated(payload));
-          }
-          break;
-
-        case "subscription.canceled":
-          if (onSubscriptionCanceled) {
-            promises.push(onSubscriptionCanceled(payload));
-          }
-          break;
-
-        case "subscription.created":
-          if (onSubscriptionCreated) {
-            promises.push(onSubscriptionCreated(payload));
-          }
-          break;
-
-        case "subscription.updated":
-          if (onSubscriptionUpdated) {
-            promises.push(onSubscriptionUpdated(payload));
-          }
-          break;
-
-        case "subscription.plan_changed":
-          if (onSubscriptionPlanChanged) {
-            promises.push(onSubscriptionPlanChanged(payload));
-          }
-          break;
-
-        case "customer.state_changed":
-          if (onCustomerStateChanged) {
-            promises.push(onCustomerStateChanged(payload));
-          }
-          break;
-
-        case "payment.received":
-          if (onPaymentReceived) {
-            promises.push(onPaymentReceived(payload));
-          }
-          break;
-
-        case "payment.recovered":
-          if (onPaymentRecovered) {
-            promises.push(onPaymentRecovered(payload));
-          }
-          break;
-
-        case "payment.failed":
-          if (onPaymentFailed) {
-            promises.push(onPaymentFailed(payload));
-          }
-          break;
-
-        case "usage.recorded":
-          if (onUsageRecorded) {
-            promises.push(onUsageRecorded(payload));
-          }
-          break;
-
-        case "invoice.created":
-          if (onInvoiceCreated) {
-            promises.push(onInvoiceCreated(payload));
-          }
-          break;
-
-        default:
-          console.log(`[Commet Webhook] Unhandled event: ${payload.event}`);
+      const handlerName = webhookEventHandlerNames[payload.event];
+      const handler = config[handlerName] as RuntimeWebhookHandler | undefined;
+      if (handler) {
+        promises.push(handler(payload));
       }
 
       try {

--- a/packages/next/src/webhooks.ts
+++ b/packages/next/src/webhooks.ts
@@ -35,25 +35,23 @@ export const Webhooks = (config: WebhooksConfig) => {
     onSubscriptionCreated,
     onSubscriptionUpdated,
     onSubscriptionPlanChanged,
+    onCustomerStateChanged,
     onPaymentReceived,
+    onPaymentRecovered,
     onPaymentFailed,
+    onUsageRecorded,
     onInvoiceCreated,
     onPayload,
     onError,
   } = config;
 
-  // Create webhook verifier instance
   const webhooks = new CommetWebhooks();
 
   return async (request: NextRequest) => {
     try {
-      // 1. Read raw request body
       const rawBody = await request.text();
-
-      // 2. Extract signature from headers
       const signature = request.headers.get("x-commet-signature");
 
-      // 3. Verify signature
       const isValid = webhooks.verify({
         payload: rawBody,
         signature,
@@ -68,7 +66,6 @@ export const Webhooks = (config: WebhooksConfig) => {
         );
       }
 
-      // 4. Parse payload
       let payload: WebhookPayload;
       try {
         payload = JSON.parse(rawBody) as WebhookPayload;
@@ -88,15 +85,12 @@ export const Webhooks = (config: WebhooksConfig) => {
         );
       }
 
-      // 5. Collect promises for parallel execution
       const promises: Promise<void>[] = [];
 
-      // Call catch-all handler if provided
       if (onPayload) {
         promises.push(onPayload(payload));
       }
 
-      // 6. Route to specific event handler
       switch (payload.event) {
         case "subscription.activated":
           if (onSubscriptionActivated) {
@@ -128,15 +122,33 @@ export const Webhooks = (config: WebhooksConfig) => {
           }
           break;
 
+        case "customer.state_changed":
+          if (onCustomerStateChanged) {
+            promises.push(onCustomerStateChanged(payload));
+          }
+          break;
+
         case "payment.received":
           if (onPaymentReceived) {
             promises.push(onPaymentReceived(payload));
           }
           break;
 
+        case "payment.recovered":
+          if (onPaymentRecovered) {
+            promises.push(onPaymentRecovered(payload));
+          }
+          break;
+
         case "payment.failed":
           if (onPaymentFailed) {
             promises.push(onPaymentFailed(payload));
+          }
+          break;
+
+        case "usage.recorded":
+          if (onUsageRecorded) {
+            promises.push(onUsageRecorded(payload));
           }
           break;
 
@@ -150,7 +162,6 @@ export const Webhooks = (config: WebhooksConfig) => {
           console.log(`[Commet Webhook] Unhandled event: ${payload.event}`);
       }
 
-      // 7. Execute all handlers in parallel
       try {
         await Promise.all(promises);
       } catch (handlerError) {
@@ -166,14 +177,12 @@ export const Webhooks = (config: WebhooksConfig) => {
             payload,
           );
         }
-        // Still return 200 to prevent retries for handler errors
         return NextResponse.json(
-          { received: true, warning: "Handler failed" },
-          { status: 200 },
+          { received: false, error: "Handler failed" },
+          { status: 500 },
         );
       }
 
-      // 8. Success response
       return NextResponse.json({ received: true }, { status: 200 });
     } catch (error) {
       console.error("[Commet Webhook] Unexpected error:", error);


### PR DESCRIPTION
## Summary

- Adds named @commet/next webhook callbacks for all 56 typed @commet/node webhook events.
- Types each named callback with its discriminated WebhookEventPayload variant while keeping onPayload as a catch-all.
- Replaces the manual event switch with an exhaustive event-to-handler map so new @commet/node events require @commet/next routing.
- Returns a non-2xx response when a webhook handler fails so failed deliveries can be retried.
- Updates the @commet/next changeset from patch to minor because this adds public API surface.

## Test Plan

- pnpm biome check --write packages/next/src .changeset/commet-next-webhook-handler-retries.md
- pnpm --filter @commet/next test -- src/webhooks.test.ts
- pnpm --filter @commet/next typecheck
- pnpm --filter @commet/next build
- pnpm build
- pnpm typecheck
- git diff --check