### PR TITLE
feat(examples): add webhook-driven SaaS template

### DIFF
--- a/examples/webhooks/.dockerignore
+++ b/examples/webhooks/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+.next
+.env
+.env.local
+.git
+.gitignore
+README.md
+drizzle
+dist

--- a/examples/webhooks/.env.example
+++ b/examples/webhooks/.env.example
@@ -1,0 +1,22 @@
+# Database
+POSTGRES_URL=postgresql://postgres:postgres@localhost:54328/webhooks_saas
+
+# Better Auth
+BETTER_AUTH_SECRET=your-secret-key-min-32-chars-long
+BETTER_AUTH_URL=http://localhost:3008
+NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:3008
+
+# Commet
+COMMET_API_KEY=your_api_key_here
+
+# Webhook signing secret.
+# Local dev: printed by `commet listen localhost:3008/api/webhooks/commet`.
+# Production: shown when you create the webhook endpoint in the Commet dashboard.
+COMMET_WEBHOOK_SECRET=your_webhook_secret_here
+
+# Welcome email (Resend). Optional in local dev: without it the welcome email is skipped.
+RESEND_API_KEY=
+EMAIL_FROM=Acme <hello@yourdomain.com>
+
+# App
+NEXT_PUBLIC_APP_URL=http://localhost:3008

--- a/examples/webhooks/.gitignore
+++ b/examples/webhooks/.gitignore
@@ -1,0 +1,42 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+.yarn/install-state.gz
+pnpm-lock.yaml
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+.env
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
+
+# Database
+drizzle/
+.commet/

--- a/examples/webhooks/actions/auth.ts
+++ b/examples/webhooks/actions/auth.ts
@@ -1,0 +1,150 @@
+"use server";
+
+import { eq } from "drizzle-orm";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth/auth";
+import { getUser } from "@/lib/auth/session";
+import { hasUsableSubscription } from "@/lib/billing/entitlements";
+import { db } from "@/lib/db/drizzle";
+import { getBillingStateForUser } from "@/lib/db/queries";
+import {
+  ActivityType,
+  activityLogs,
+  type NewActivityLog,
+  user,
+} from "@/lib/db/schema";
+import { safeRedirectPath } from "@/lib/redirects";
+import {
+  updateAccountSchema,
+  updatePasswordSchema,
+} from "@/lib/validations/auth";
+
+type ActionState = {
+  error?: string;
+  success?: string;
+  fieldErrors?: Record<string, string[] | undefined>;
+  [key: string]:
+    | string
+    | string[]
+    | Record<string, string[] | undefined>
+    | undefined;
+};
+
+async function logActivity(
+  userId: string,
+  type: ActivityType,
+  ipAddress?: string,
+) {
+  const newActivity: NewActivityLog = {
+    userId,
+    action: type,
+    ipAddress,
+  };
+  await db.insert(activityLogs).values(newActivity);
+}
+
+export async function getPostAuthRedirect(fallback = "/dashboard") {
+  const redirectPath = safeRedirectPath(fallback);
+  const currentUser = await getUser();
+  if (!currentUser) {
+    return "/sign-in";
+  }
+
+  if (redirectPath !== "/dashboard") {
+    return redirectPath;
+  }
+
+  const billing = await getBillingStateForUser(currentUser.id);
+  return hasUsableSubscription(billing?.subscriptionStatus)
+    ? "/dashboard"
+    : "/pricing";
+}
+
+export async function signOut() {
+  const currentUser = await getUser();
+  if (currentUser) {
+    await logActivity(currentUser.id, ActivityType.SIGN_OUT);
+  }
+  redirect("/sign-in");
+}
+
+export async function updateAccount(
+  _prevState: ActionState,
+  formData: FormData,
+): Promise<ActionState> {
+  const currentUser = await getUser();
+  if (!currentUser) {
+    return { error: "Not authenticated" };
+  }
+
+  const rawData = {
+    name: formData.get("name") as string,
+    email: formData.get("email") as string,
+  };
+
+  const result = updateAccountSchema.safeParse(rawData);
+  if (!result.success) {
+    return {
+      error: "Validation failed",
+      fieldErrors: result.error.flatten().fieldErrors,
+    };
+  }
+
+  const { name, email } = result.data;
+
+  await db
+    .update(user)
+    .set({ name, email, updatedAt: new Date() })
+    .where(eq(user.id, currentUser.id));
+
+  await logActivity(currentUser.id, ActivityType.UPDATE_ACCOUNT);
+
+  return { success: "Account updated successfully." };
+}
+
+export async function updatePassword(
+  _prevState: ActionState,
+  formData: FormData,
+): Promise<ActionState> {
+  const currentUser = await getUser();
+  if (!currentUser) {
+    return { error: "Not authenticated" };
+  }
+
+  const rawData = {
+    currentPassword: formData.get("currentPassword") as string,
+    newPassword: formData.get("newPassword") as string,
+    confirmPassword: formData.get("confirmPassword") as string,
+  };
+
+  const result = updatePasswordSchema.safeParse(rawData);
+  if (!result.success) {
+    return {
+      error: "Validation failed",
+      fieldErrors: result.error.flatten().fieldErrors,
+    };
+  }
+
+  const { currentPassword, newPassword } = result.data;
+
+  try {
+    await auth.api.changePassword({
+      body: {
+        currentPassword,
+        newPassword,
+        revokeOtherSessions: false,
+      },
+      headers: await headers(),
+    });
+
+    await logActivity(currentUser.id, ActivityType.UPDATE_PASSWORD);
+
+    return { success: "Password updated successfully." };
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      return { error: error.message || "Failed to update password" };
+    }
+    return { error: "Failed to update password" };
+  }
+}

--- a/examples/webhooks/actions/plans.ts
+++ b/examples/webhooks/actions/plans.ts
@@ -1,0 +1,34 @@
+"use server";
+
+import type { Plan } from "@commet/node";
+import { unstable_cache } from "next/cache";
+import { commet } from "@/lib/commet";
+
+const getCachedPlans = unstable_cache(
+  async () => {
+    const result = await commet.plans.list();
+    if (!result.success || !result.data) {
+      throw new Error("Unable to load plans");
+    }
+    return result.data;
+  },
+  ["plans"],
+  { revalidate: 3600, tags: ["plans"] },
+);
+
+export async function getPlansAction(): Promise<{
+  success: boolean;
+  data?: Plan[];
+  error?: string;
+}> {
+  try {
+    const plans = await getCachedPlans();
+    return {
+      success: true,
+      data: plans,
+    };
+  } catch (error) {
+    console.error("Error fetching plans:", error);
+    return { success: false, error: "Unable to load plans. Please try again." };
+  }
+}

--- a/examples/webhooks/app/(auth)/layout.tsx
+++ b/examples/webhooks/app/(auth)/layout.tsx
@@ -1,0 +1,11 @@
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-h-dvh items-center justify-center p-4">
+      <div className="w-full max-w-sm">{children}</div>
+    </div>
+  );
+}

--- a/examples/webhooks/app/(auth)/sign-in/page.tsx
+++ b/examples/webhooks/app/(auth)/sign-in/page.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useState } from "react";
+import { getPostAuthRedirect } from "@/actions/auth";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { signIn } from "@/lib/auth/auth-client";
+import { handlePostSignupCheckout } from "@/lib/payments/actions";
+import { normalizePlanCode } from "@/lib/plans";
+import { buildInternalHref, safeRedirectPath } from "@/lib/redirects";
+
+function SignInContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const redirect = safeRedirectPath(searchParams.get("redirect"));
+  const planCode = normalizePlanCode(searchParams.get("planCode"));
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setLoading(true);
+    setError("");
+
+    const formData = new FormData(event.currentTarget);
+    const email = formData.get("email") as string;
+    const password = formData.get("password") as string;
+
+    const result = await signIn.email({ email, password });
+
+    if (result.error) {
+      setError(result.error.message || "Invalid credentials");
+      setLoading(false);
+      return;
+    }
+
+    if (planCode) {
+      const checkoutResult = await handlePostSignupCheckout(planCode);
+      if (checkoutResult.success && checkoutResult.checkoutUrl) {
+        window.location.href = checkoutResult.checkoutUrl;
+        return;
+      }
+      setError(
+        checkoutResult.error ||
+          "We couldn't continue with checkout. Please try again.",
+      );
+      setLoading(false);
+      return;
+    }
+
+    router.push(await getPostAuthRedirect(redirect));
+  }
+
+  const signUpHref = planCode
+    ? buildInternalHref("/sign-up", {
+        planCode,
+        redirect: redirect !== "/dashboard" ? redirect : null,
+      })
+    : "/sign-up";
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Sign in</CardTitle>
+        <CardDescription>Enter your credentials to continue.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {planCode && (
+          <div className="mb-4 flex flex-col rounded-lg border border-primary/20 bg-primary/5 px-3 py-2 text-sm">
+            <span className="font-medium">Selected plan</span>
+            <span className="text-muted-foreground">
+              Sign in to continue with {planCode}.
+            </span>
+          </div>
+        )}
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="email">Email</Label>
+            <Input id="email" name="email" type="email" required />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="password">Password</Label>
+            <Input id="password" name="password" type="password" required />
+          </div>
+          {error && (
+            <p className="text-sm text-destructive-foreground">{error}</p>
+          )}
+          <Button type="submit" disabled={loading}>
+            {loading ? "Signing in..." : "Sign in"}
+          </Button>
+          <p className="text-center text-sm text-muted-foreground">
+            Don&apos;t have an account?{" "}
+            <Link
+              href={signUpHref}
+              className="text-foreground underline underline-offset-4"
+            >
+              Sign up
+            </Link>
+          </p>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function SignInPage() {
+  return (
+    <Suspense>
+      <SignInContent />
+    </Suspense>
+  );
+}

--- a/examples/webhooks/app/(auth)/sign-up/page.tsx
+++ b/examples/webhooks/app/(auth)/sign-up/page.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useState } from "react";
+import { getPostAuthRedirect } from "@/actions/auth";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { signUp } from "@/lib/auth/auth-client";
+import { handlePostSignupCheckout } from "@/lib/payments/actions";
+import { normalizePlanCode } from "@/lib/plans";
+import { buildInternalHref, safeRedirectPath } from "@/lib/redirects";
+
+function SignUpContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const redirect = safeRedirectPath(searchParams.get("redirect"));
+  const planCode = normalizePlanCode(searchParams.get("planCode"));
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setLoading(true);
+    setError("");
+
+    const formData = new FormData(event.currentTarget);
+    const name = formData.get("name") as string;
+    const email = formData.get("email") as string;
+    const password = formData.get("password") as string;
+
+    const result = await signUp.email({ name, email, password });
+
+    if (result.error) {
+      setError(result.error.message || "Something went wrong");
+      setLoading(false);
+      return;
+    }
+
+    if (planCode) {
+      const checkoutResult = await handlePostSignupCheckout(planCode);
+      if (checkoutResult.success && checkoutResult.checkoutUrl) {
+        window.location.href = checkoutResult.checkoutUrl;
+        return;
+      }
+      setError(
+        checkoutResult.error ||
+          "We couldn't continue with checkout. Please try again.",
+      );
+      setLoading(false);
+      return;
+    }
+
+    router.push(await getPostAuthRedirect(redirect));
+  }
+
+  const signInHref = planCode
+    ? buildInternalHref("/sign-in", {
+        planCode,
+        redirect: redirect !== "/dashboard" ? redirect : null,
+      })
+    : "/sign-in";
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Create an account</CardTitle>
+        <CardDescription>Get started with your subscription.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {planCode && (
+          <div className="mb-4 flex flex-col rounded-lg border border-primary/20 bg-primary/5 px-3 py-2 text-sm">
+            <span className="font-medium">Selected plan</span>
+            <span className="text-muted-foreground">
+              Complete your signup to continue with {planCode}.
+            </span>
+          </div>
+        )}
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="name">Name</Label>
+            <Input id="name" name="name" type="text" required />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="email">Email</Label>
+            <Input id="email" name="email" type="email" required />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="password">Password</Label>
+            <Input
+              id="password"
+              name="password"
+              type="password"
+              required
+              minLength={8}
+            />
+          </div>
+          {error && (
+            <p className="text-sm text-destructive-foreground">{error}</p>
+          )}
+          <Button type="submit" disabled={loading}>
+            {loading ? "Creating account..." : "Sign up"}
+          </Button>
+          <p className="text-center text-sm text-muted-foreground">
+            Already have an account?{" "}
+            <Link
+              href={signInHref}
+              className="text-foreground underline underline-offset-4"
+            >
+              Sign in
+            </Link>
+          </p>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function SignUpPage() {
+  return (
+    <Suspense>
+      <SignUpContent />
+    </Suspense>
+  );
+}

--- a/examples/webhooks/app/(dashboard)/dashboard/billing/page.tsx
+++ b/examples/webhooks/app/(dashboard)/dashboard/billing/page.tsx
@@ -1,0 +1,94 @@
+import { ExternalLink } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { getUser } from "@/lib/auth/session";
+import { resolveAccessForBillingState } from "@/lib/billing/entitlements";
+import { getBillingStateForUser } from "@/lib/db/queries";
+
+function formatStatus(status: string): string {
+  if (status === "none") return "No subscription";
+  if (status === "past_due") return "Past due";
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+export default async function BillingPage() {
+  const user = await getUser();
+  const billing = await getBillingStateForUser(user!.id);
+  const access = resolveAccessForBillingState(billing);
+  const hasSubscription = access.status !== "none";
+
+  return (
+    <div className="flex flex-1 flex-col gap-6 p-6">
+      <div>
+        <h1 className="text-lg font-semibold">Billing</h1>
+        <p className="text-sm text-muted-foreground">
+          Your subscription and payment details — synced from webhooks, no
+          Commet API call.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div className="flex flex-col gap-1.5">
+            <CardTitle>Subscription</CardTitle>
+            <CardDescription>Your current plan and status.</CardDescription>
+          </div>
+          {hasSubscription && (
+            <Button
+              variant="outline"
+              size="sm"
+              nativeButton={false}
+              render={
+                <a
+                  href="/api/commet/portal"
+                  aria-label="Manage billing"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Manage billing
+                  <ExternalLink className="size-3" />
+                </a>
+              }
+            />
+          )}
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3">
+          {hasSubscription ? (
+            <>
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-muted-foreground">Plan</span>
+                <span className="text-sm font-medium">{access.planLabel}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-muted-foreground">Status</span>
+                <span className="text-sm font-medium">
+                  {formatStatus(access.status)}
+                </span>
+              </div>
+              {billing?.billingInterval && (
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-muted-foreground">
+                    Billing interval
+                  </span>
+                  <span className="text-sm font-medium capitalize">
+                    {billing.billingInterval}
+                  </span>
+                </div>
+              )}
+            </>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No active subscription.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/examples/webhooks/app/(dashboard)/dashboard/billing/page.tsx
+++ b/examples/webhooks/app/(dashboard)/dashboard/billing/page.tsx
@@ -1,4 +1,5 @@
 import { ExternalLink } from "lucide-react";
+import { redirect } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -19,7 +20,12 @@ function formatStatus(status: string): string {
 
 export default async function BillingPage() {
   const user = await getUser();
-  const billing = await getBillingStateForUser(user!.id);
+
+  if (!user) {
+    redirect("/sign-in");
+  }
+
+  const billing = await getBillingStateForUser(user.id);
   const access = resolveAccessForBillingState(billing);
   const hasSubscription = access.status !== "none";
 

--- a/examples/webhooks/app/(dashboard)/dashboard/events/page.tsx
+++ b/examples/webhooks/app/(dashboard)/dashboard/events/page.tsx
@@ -1,0 +1,96 @@
+import { AutoRefresh } from "@/components/auto-refresh";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { getRecentWebhookEvents } from "@/lib/db/queries";
+import { cn } from "@/lib/utils";
+
+function eventBadgeClasses(event: string): string {
+  if (event.startsWith("payment.")) {
+    return "border-amber-600/30 bg-amber-600/10 text-amber-700 dark:text-amber-500";
+  }
+  if (event.startsWith("invoice.")) {
+    return "border-border bg-muted text-muted-foreground";
+  }
+  return "border-primary/30 bg-primary/10 text-primary";
+}
+
+function formatRelativeTime(receivedAt: Date): string {
+  const elapsedSeconds = Math.round((Date.now() - receivedAt.getTime()) / 1000);
+  if (elapsedSeconds < 60) return `${elapsedSeconds}s ago`;
+  if (elapsedSeconds < 3600) return `${Math.floor(elapsedSeconds / 60)}m ago`;
+  if (elapsedSeconds < 86400)
+    return `${Math.floor(elapsedSeconds / 3600)}h ago`;
+  return receivedAt.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export default async function EventsPage() {
+  const events = await getRecentWebhookEvents();
+
+  return (
+    <div className="flex flex-1 flex-col gap-6 p-6">
+      <AutoRefresh seconds={4} />
+      <div>
+        <h1 className="text-lg font-semibold">Events</h1>
+        <p className="text-sm text-muted-foreground">
+          Webhooks received from Commet for your account, newest first.
+          Refreshes every few seconds.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Webhook feed</CardTitle>
+          <CardDescription>
+            Last {events.length} events recorded by /api/webhooks/commet.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col">
+          {events.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No events yet. Run{" "}
+              <code className="bg-muted px-1 py-0.5 font-mono text-xs">
+                commet listen localhost:3008/api/webhooks/commet
+              </code>{" "}
+              and subscribe to a plan to see webhooks arrive here.
+            </p>
+          ) : (
+            events.map((webhookEvent) => (
+              <details
+                key={webhookEvent.id}
+                className="group border-b py-3 last:border-b-0"
+              >
+                <summary className="flex cursor-pointer list-none items-center gap-3 [&::-webkit-details-marker]:hidden">
+                  <span
+                    className={cn(
+                      "border px-2 py-0.5 font-mono text-xs",
+                      eventBadgeClasses(webhookEvent.event),
+                    )}
+                  >
+                    {webhookEvent.event}
+                  </span>
+                  <span className="flex-1 truncate text-sm text-muted-foreground">
+                    {webhookEvent.commetCustomerId ?? "—"}
+                  </span>
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {formatRelativeTime(webhookEvent.receivedAt)}
+                  </span>
+                </summary>
+                <pre className="mt-3 overflow-x-auto bg-muted p-3 font-mono text-xs leading-relaxed">
+                  {JSON.stringify(webhookEvent.payload, null, 2)}
+                </pre>
+              </details>
+            ))
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/examples/webhooks/app/(dashboard)/dashboard/layout.tsx
+++ b/examples/webhooks/app/(dashboard)/dashboard/layout.tsx
@@ -1,5 +1,6 @@
 import { CreditCard, Home, Lock, Tags, Webhook } from "lucide-react";
 import Link from "next/link";
+import { redirect } from "next/navigation";
 import { PastDueBanner } from "@/components/past-due-banner";
 import { SignOutButton } from "@/components/shared/sign-out-button";
 import { Separator } from "@/components/ui/separator";
@@ -36,7 +37,12 @@ export default async function DashboardInnerLayout({
   children: React.ReactNode;
 }) {
   const user = await getUser();
-  const billing = await getBillingStateForUser(user!.id);
+
+  if (!user) {
+    redirect("/sign-in");
+  }
+
+  const billing = await getBillingStateForUser(user.id);
   const hasPlan = hasUsableSubscription(billing?.subscriptionStatus);
 
   return (

--- a/examples/webhooks/app/(dashboard)/dashboard/layout.tsx
+++ b/examples/webhooks/app/(dashboard)/dashboard/layout.tsx
@@ -1,0 +1,78 @@
+import { CreditCard, Home, Lock, Tags, Webhook } from "lucide-react";
+import Link from "next/link";
+import { PastDueBanner } from "@/components/past-due-banner";
+import { SignOutButton } from "@/components/shared/sign-out-button";
+import { Separator } from "@/components/ui/separator";
+import { getUser } from "@/lib/auth/session";
+import { hasUsableSubscription } from "@/lib/billing/entitlements";
+import { getBillingStateForUser } from "@/lib/db/queries";
+import { cn } from "@/lib/utils";
+
+function NavLink({
+  href,
+  children,
+  className,
+}: {
+  href: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className={cn(
+        "flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm font-medium hover:bg-muted",
+        className,
+      )}
+    >
+      {children}
+    </Link>
+  );
+}
+
+export default async function DashboardInnerLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const user = await getUser();
+  const billing = await getBillingStateForUser(user!.id);
+  const hasPlan = hasUsableSubscription(billing?.subscriptionStatus);
+
+  return (
+    <div className="flex flex-1 flex-col">
+      {billing?.subscriptionStatus === "past_due" && <PastDueBanner />}
+      <div className="flex flex-1">
+        <aside className="sticky top-12 flex h-[calc(100dvh-3rem)] w-56 flex-col border-r bg-sidebar px-2 py-4">
+          <nav className="flex flex-1 flex-col gap-1">
+            <NavLink href="/dashboard">
+              <Home className="size-4" />
+              Overview
+            </NavLink>
+            <NavLink href="/dashboard/events">
+              <Webhook className="size-4" />
+              Events
+            </NavLink>
+            <NavLink href="/dashboard/billing">
+              <CreditCard className="size-4" />
+              Billing
+            </NavLink>
+            {!hasPlan && (
+              <NavLink href="/pricing">
+                <Tags className="size-4" />
+                Pricing
+              </NavLink>
+            )}
+            <NavLink href="/dashboard/security">
+              <Lock className="size-4" />
+              Security
+            </NavLink>
+          </nav>
+          <Separator className="my-2" />
+          <SignOutButton />
+        </aside>
+        <main className="flex flex-1 flex-col">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/examples/webhooks/app/(dashboard)/dashboard/page.tsx
+++ b/examples/webhooks/app/(dashboard)/dashboard/page.tsx
@@ -1,0 +1,126 @@
+import { redirect } from "next/navigation";
+import { AutoRefresh } from "@/components/auto-refresh";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { getUser } from "@/lib/auth/session";
+import {
+  hasUsableSubscription,
+  resolveAccessForBillingState,
+} from "@/lib/billing/entitlements";
+import { getBillingStateForUser } from "@/lib/db/queries";
+import type { BillingFeature } from "@/lib/db/schema";
+
+function formatPeriodEnd(periodEnd: Date | null): string {
+  if (!periodEnd) return "—";
+  return periodEnd.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatStatus(status: string): string {
+  if (status === "none") return "No subscription";
+  if (status === "past_due") return "Past due";
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+function formatFeatureValue(feature: BillingFeature): string {
+  if (feature.unlimited) return "Unlimited";
+  if (feature.type === "boolean") return feature.enabled ? "Enabled" : "Off";
+  if (feature.type === "usage" && typeof feature.remaining === "number") {
+    return `${feature.remaining.toLocaleString()} remaining`;
+  }
+  if (typeof feature.included === "number") {
+    return feature.included.toLocaleString();
+  }
+  if (typeof feature.current === "number") {
+    return feature.current.toLocaleString();
+  }
+  return feature.allowed ? "Included" : "Not included";
+}
+
+export default async function DashboardPage() {
+  const user = await getUser();
+  const billing = await getBillingStateForUser(user!.id);
+
+  if (!hasUsableSubscription(billing?.subscriptionStatus)) {
+    redirect("/pricing");
+  }
+
+  const access = resolveAccessForBillingState(billing);
+
+  return (
+    <div className="flex flex-1 flex-col gap-6 p-6">
+      <AutoRefresh seconds={4} />
+      <div>
+        <h1 className="text-lg font-semibold">Dashboard</h1>
+        <p className="text-sm text-muted-foreground">
+          Your subscription, renewal date, and included limits.
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Current plan</CardTitle>
+            <CardDescription>Your current subscription.</CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-muted-foreground">Plan</span>
+              <span className="text-sm font-medium">{access.planLabel}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-muted-foreground">Status</span>
+              <span className="text-sm font-medium">
+                {formatStatus(access.status)}
+              </span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-muted-foreground">
+                Current period ends
+              </span>
+              <span className="text-sm font-medium">
+                {formatPeriodEnd(billing?.currentPeriodEnd ?? null)}
+              </span>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Features</CardTitle>
+            <CardDescription>Included limits and access.</CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3">
+            {access.features.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No included features for this plan.
+              </p>
+            ) : (
+              access.features.map((feature) => (
+                <div
+                  key={feature.code}
+                  className="flex items-center justify-between"
+                >
+                  <span className="text-sm text-muted-foreground">
+                    {feature.name}
+                  </span>
+                  <span className="text-sm font-medium">
+                    {formatFeatureValue(feature)}
+                  </span>
+                </div>
+              ))
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/examples/webhooks/app/(dashboard)/dashboard/page.tsx
+++ b/examples/webhooks/app/(dashboard)/dashboard/page.tsx
@@ -47,7 +47,12 @@ function formatFeatureValue(feature: BillingFeature): string {
 
 export default async function DashboardPage() {
   const user = await getUser();
-  const billing = await getBillingStateForUser(user!.id);
+
+  if (!user) {
+    redirect("/sign-in");
+  }
+
+  const billing = await getBillingStateForUser(user.id);
 
   if (!hasUsableSubscription(billing?.subscriptionStatus)) {
     redirect("/pricing");

--- a/examples/webhooks/app/(dashboard)/dashboard/security/page.tsx
+++ b/examples/webhooks/app/(dashboard)/dashboard/security/page.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useActionState } from "react";
+import { updatePassword } from "@/actions/auth";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useFormToast } from "@/hooks/use-form-toast";
+
+type PasswordState = {
+  currentPassword?: string;
+  newPassword?: string;
+  confirmPassword?: string;
+  error?: string;
+  success?: string;
+  fieldErrors?: Record<string, string[] | undefined>;
+};
+
+export default function SecurityPage() {
+  const [passwordState, passwordAction, isPasswordPending] = useActionState<
+    PasswordState,
+    FormData
+  >(updatePassword, {});
+
+  useFormToast(passwordState);
+
+  return (
+    <div className="flex flex-1 flex-col gap-6 p-6">
+      <div>
+        <h1 className="text-lg font-semibold">Security</h1>
+        <p className="text-sm text-muted-foreground">
+          Manage your password and account security.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Change Password</CardTitle>
+          <CardDescription>Update your account password.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="flex flex-col gap-4" action={passwordAction}>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="current-password">Current Password</Label>
+              <Input
+                id="current-password"
+                name="currentPassword"
+                type="password"
+                autoComplete="current-password"
+                required
+                minLength={8}
+              />
+              {passwordState.fieldErrors?.currentPassword?.[0] && (
+                <p className="text-sm text-destructive-foreground">
+                  {passwordState.fieldErrors.currentPassword[0]}
+                </p>
+              )}
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="new-password">New Password</Label>
+              <Input
+                id="new-password"
+                name="newPassword"
+                type="password"
+                autoComplete="new-password"
+                required
+                minLength={8}
+              />
+              {passwordState.fieldErrors?.newPassword?.[0] && (
+                <p className="text-sm text-destructive-foreground">
+                  {passwordState.fieldErrors.newPassword[0]}
+                </p>
+              )}
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="confirm-password">Confirm New Password</Label>
+              <Input
+                id="confirm-password"
+                name="confirmPassword"
+                type="password"
+                required
+                minLength={8}
+              />
+              {passwordState.fieldErrors?.confirmPassword?.[0] && (
+                <p className="text-sm text-destructive-foreground">
+                  {passwordState.fieldErrors.confirmPassword[0]}
+                </p>
+              )}
+            </div>
+            <Button type="submit" disabled={isPasswordPending}>
+              {isPasswordPending ? "Updating..." : "Update password"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/examples/webhooks/app/(dashboard)/layout.tsx
+++ b/examples/webhooks/app/(dashboard)/layout.tsx
@@ -1,0 +1,16 @@
+import { redirect } from "next/navigation";
+import { getUser } from "@/lib/auth/session";
+
+export default async function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const user = await getUser();
+
+  if (!user) {
+    redirect("/sign-in");
+  }
+
+  return <>{children}</>;
+}

--- a/examples/webhooks/app/api/auth/[...all]/route.ts
+++ b/examples/webhooks/app/api/auth/[...all]/route.ts
@@ -1,0 +1,6 @@
+import { toNextJsHandler } from "better-auth/next-js";
+import { auth } from "@/lib/auth/auth";
+
+const { GET, POST } = toNextJsHandler(auth);
+
+export { GET, POST };

--- a/examples/webhooks/app/api/commet/portal/route.ts
+++ b/examples/webhooks/app/api/commet/portal/route.ts
@@ -1,0 +1,11 @@
+import { CustomerPortal } from "@commet/next";
+import { auth } from "@/lib/auth/auth";
+import { env } from "@/lib/env";
+
+export const GET = CustomerPortal({
+  apiKey: env.COMMET_API_KEY,
+  getCustomerId: async (req) => {
+    const session = await auth.api.getSession({ headers: req.headers });
+    return session?.user.id ?? null;
+  },
+});

--- a/examples/webhooks/app/api/webhooks/commet/route.ts
+++ b/examples/webhooks/app/api/webhooks/commet/route.ts
@@ -1,0 +1,109 @@
+import { createHash } from "node:crypto";
+import { type WebhookPayload, Webhooks } from "@commet/node";
+import { type NextRequest, NextResponse } from "next/server";
+import {
+  recordCurrentPeriod,
+  recordUsageFromEvent,
+  resolveActivatedUserForWelcome,
+  restoreAccessAfterPayment,
+  syncBillingStateFromSnapshot,
+} from "@/lib/billing/sync";
+import {
+  markWebhookEventCompleted,
+  markWebhookEventFailed,
+  recordWebhookEvent,
+} from "@/lib/billing/webhook-events";
+import { env } from "@/lib/env";
+import { sendWelcomeEmail } from "@/lib/notifications/email";
+import { notifyTeamOfNewSubscription } from "@/lib/notifications/team";
+
+export async function POST(request: NextRequest) {
+  const webhooks = new Webhooks();
+  const rawBody = await request.text();
+  const signature = request.headers.get("x-commet-signature");
+
+  const isValid = webhooks.verify({
+    payload: rawBody,
+    signature,
+    secret: env.COMMET_WEBHOOK_SECRET,
+  });
+
+  if (!isValid) {
+    return NextResponse.json(
+      { received: false, error: "Invalid signature" },
+      { status: 403 },
+    );
+  }
+
+  let payload: WebhookPayload;
+  try {
+    payload = JSON.parse(rawBody) as WebhookPayload;
+  } catch (error) {
+    console.error("[commet-webhook] invalid payload", { error });
+    return NextResponse.json(
+      { received: false, error: "Invalid payload" },
+      { status: 400 },
+    );
+  }
+
+  const eventId = createHash("sha256").update(rawBody).digest("hex");
+  const insertResult = await recordWebhookEvent({ eventId, payload });
+  if (insertResult === "completed") {
+    return NextResponse.json({ received: true, duplicate: true });
+  }
+  if (insertResult === "processing") {
+    return NextResponse.json(
+      { received: false, error: "Event is already processing" },
+      { status: 400 },
+    );
+  }
+
+  const criticalHandlers: Promise<void>[] = [];
+  const notificationHandlers: Promise<void>[] = [];
+
+  switch (payload.event) {
+    case "customer.state_changed":
+      criticalHandlers.push(syncBillingStateFromSnapshot(payload.data));
+      if (payload.data.trigger === "subscription_activated") {
+        notificationHandlers.push(
+          resolveActivatedUserForWelcome(payload.data).then((activatedUser) =>
+            Promise.all([
+              sendWelcomeEmail(activatedUser),
+              notifyTeamOfNewSubscription(activatedUser),
+            ]).then(() => undefined),
+          ),
+        );
+      }
+      break;
+
+    case "subscription.activated":
+    case "subscription.reactivated":
+      criticalHandlers.push(recordCurrentPeriod(payload.data));
+      break;
+
+    case "payment.received":
+    case "payment.recovered":
+      criticalHandlers.push(restoreAccessAfterPayment(payload.data));
+      break;
+
+    case "usage.recorded":
+      criticalHandlers.push(recordUsageFromEvent(payload.data));
+      break;
+  }
+
+  try {
+    await Promise.all(criticalHandlers);
+  } catch (error) {
+    await markWebhookEventFailed(eventId);
+    console.error("[commet-webhook] handler failed", { error, payload });
+    return NextResponse.json(
+      { received: false, error: "Handler failed" },
+      { status: 500 },
+    );
+  }
+
+  await markWebhookEventCompleted(eventId);
+  await Promise.allSettled(notificationHandlers);
+
+  return NextResponse.json({ received: true }, { status: 200 });
+}

--- a/examples/webhooks/app/checkout/page.tsx
+++ b/examples/webhooks/app/checkout/page.tsx
@@ -1,0 +1,33 @@
+import { redirect } from "next/navigation";
+import { env } from "@/lib/env";
+import { createCheckoutSession } from "@/lib/payments/commet";
+import { normalizePlanCode } from "@/lib/plans";
+
+type CheckoutPageProps = {
+  searchParams: Promise<{
+    planCode?: string | string[];
+  }>;
+};
+
+function readPlanCode(planCode: string | string[] | undefined): string | null {
+  if (!planCode) return null;
+  if (Array.isArray(planCode)) {
+    return normalizePlanCode(planCode[0] ?? null);
+  }
+  return normalizePlanCode(planCode);
+}
+
+export default async function CheckoutPage({
+  searchParams,
+}: CheckoutPageProps) {
+  const params = await searchParams;
+  const planCode = readPlanCode(params?.planCode);
+
+  if (!planCode) {
+    redirect("/pricing?error=missing_plan");
+  }
+
+  const successUrl = `${env.NEXT_PUBLIC_APP_URL}/dashboard`;
+
+  await createCheckoutSession({ planCode, successUrl });
+}

--- a/examples/webhooks/app/globals.css
+++ b/examples/webhooks/app/globals.css
@@ -1,0 +1,132 @@
+@import "tailwindcss";
+@import "tw-animate-css";
+@import "shadcn/tailwind.css";
+
+@custom-variant dark (&:is(.dark *));
+
+:root {
+  --background: oklch(0.98 0.012 65);
+  --foreground: oklch(0.17 0.018 52);
+  --card: oklch(0.98 0.012 65);
+  --card-foreground: oklch(0.17 0.018 52);
+  --popover: oklch(0.98 0.012 65);
+  --popover-foreground: oklch(0.17 0.018 52);
+  --primary: oklch(0.2 0.018 52);
+  --primary-foreground: oklch(0.97 0.008 65);
+  --secondary: oklch(0.95 0.014 65);
+  --secondary-foreground: oklch(0.28 0.028 52);
+  --muted: oklch(0.95 0.014 65);
+  --muted-foreground: oklch(0.52 0.022 57);
+  --accent: oklch(0.95 0.014 65);
+  --accent-foreground: oklch(0.28 0.028 52);
+  --destructive: oklch(0.55 0.22 27);
+  --destructive-foreground: oklch(0.98 0.01 27);
+  --border: oklch(0.89 0.017 62);
+  --input: oklch(0.89 0.017 62);
+  --ring: oklch(0.2 0.018 52);
+  --chart-1: oklch(0.6 0.16 45);
+  --chart-2: oklch(0.6 0.1 175);
+  --chart-3: oklch(0.75 0.15 80);
+  --chart-4: oklch(0.45 0.12 35);
+  --chart-5: oklch(0.65 0.12 15);
+  --radius: 0px;
+  --sidebar-background: oklch(0.97 0.014 65);
+  --sidebar-foreground: oklch(0.17 0.018 52);
+  --sidebar-primary: oklch(0.2 0.018 52);
+  --sidebar-primary-foreground: oklch(0.97 0.008 65);
+  --sidebar-accent: oklch(0.95 0.014 65);
+  --sidebar-accent-foreground: oklch(0.28 0.028 52);
+  --sidebar-border: oklch(0.89 0.017 62);
+  --sidebar-ring: oklch(0.2 0.018 52);
+}
+
+.dark {
+  --background: oklch(0.155 0.015 55);
+  --foreground: oklch(0.93 0.01 75);
+  --card: oklch(0.155 0.015 55);
+  --card-foreground: oklch(0.93 0.01 75);
+  --popover: oklch(0.155 0.015 55);
+  --popover-foreground: oklch(0.93 0.01 75);
+  --primary: oklch(0.93 0.015 60);
+  --primary-foreground: oklch(0.155 0.015 55);
+  --secondary: oklch(0.24 0.015 55);
+  --secondary-foreground: oklch(0.93 0.01 75);
+  --muted: oklch(0.24 0.015 55);
+  --muted-foreground: oklch(0.65 0.015 60);
+  --accent: oklch(0.24 0.015 55);
+  --accent-foreground: oklch(0.93 0.01 75);
+  --destructive: oklch(0.4 0.14 27);
+  --destructive-foreground: oklch(0.65 0.22 27);
+  --border: oklch(0.28 0.015 55);
+  --input: oklch(0.28 0.015 55);
+  --ring: oklch(0.6 0.12 50);
+  --chart-1: oklch(0.65 0.16 45);
+  --chart-2: oklch(0.65 0.1 175);
+  --chart-3: oklch(0.72 0.14 80);
+  --chart-4: oklch(0.55 0.12 35);
+  --chart-5: oklch(0.62 0.14 15);
+  --sidebar-background: oklch(0.185 0.015 55);
+  --sidebar-foreground: oklch(0.93 0.01 75);
+  --sidebar-primary: oklch(0.93 0.015 60);
+  --sidebar-primary-foreground: oklch(0.155 0.015 55);
+  --sidebar-accent: oklch(0.24 0.015 55);
+  --sidebar-accent-foreground: oklch(0.93 0.01 75);
+  --sidebar-border: oklch(0.28 0.015 55);
+  --sidebar-ring: oklch(0.5 0.1 50);
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --color-sidebar: var(--sidebar-background);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+  --font-heading: var(--font-sans);
+  --font-sans: var(--font-sans);
+  --radius-2xl: calc(var(--radius) * 1.8);
+  --radius-3xl: calc(var(--radius) * 2.2);
+  --radius-4xl: calc(var(--radius) * 2.6);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+  html {
+    @apply font-sans;
+  }
+}

--- a/examples/webhooks/app/layout.tsx
+++ b/examples/webhooks/app/layout.tsx
@@ -1,0 +1,50 @@
+import { Analytics } from "@vercel/analytics/next";
+import "./globals.css";
+import type { Metadata, Viewport } from "next";
+import { IBM_Plex_Sans } from "next/font/google";
+import { Toaster } from "sonner";
+import { TemplateHeader } from "@/components/template-header";
+
+export const metadata: Metadata = {
+  title: "Webhooks SaaS",
+  description:
+    "Webhook-driven SaaS template with subscription billing via Commet.",
+  icons: {
+    icon: [
+      {
+        media: "(prefers-color-scheme: light)",
+        url: "/favicon-light.svg",
+      },
+      {
+        media: "(prefers-color-scheme: dark)",
+        url: "/favicon-dark.svg",
+      },
+    ],
+  },
+};
+
+export const viewport: Viewport = {
+  maximumScale: 1,
+};
+
+const ibmPlexSans = IBM_Plex_Sans({
+  subsets: ["latin"],
+  weight: ["300", "400", "500", "600"],
+});
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" className={ibmPlexSans.className} suppressHydrationWarning>
+      <body className="flex min-h-dvh flex-col antialiased">
+        <TemplateHeader templateName="Webhooks SaaS" />
+        {children}
+        <Toaster position="top-right" richColors />
+        <Analytics />
+      </body>
+    </html>
+  );
+}

--- a/examples/webhooks/app/not-found.tsx
+++ b/examples/webhooks/app/not-found.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center gap-4">
+      <h1 className="text-2xl font-semibold">404</h1>
+      <p className="text-muted-foreground">Page not found.</p>
+      <Button variant="outline" nativeButton={false} render={<Link href="/" />}>
+        Go home
+      </Button>
+    </div>
+  );
+}

--- a/examples/webhooks/app/page.tsx
+++ b/examples/webhooks/app/page.tsx
@@ -1,0 +1,82 @@
+import { ArrowRight, Bell, Mail, Webhook } from "lucide-react";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { getUser } from "@/lib/auth/session";
+
+function FeatureCard({
+  icon: Icon,
+  title,
+  description,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex flex-col gap-2 border p-5">
+      <Icon className="size-5 text-muted-foreground" />
+      <h3 className="text-sm font-medium">{title}</h3>
+      <p className="text-sm text-muted-foreground">{description}</p>
+    </div>
+  );
+}
+
+export default async function HomePage() {
+  const user = await getUser();
+
+  if (user) {
+    redirect("/dashboard");
+  }
+
+  return (
+    <div className="flex flex-1 flex-col">
+      <main className="flex flex-1 flex-col items-center justify-center gap-16 px-4 py-20">
+        <section className="flex max-w-lg flex-col items-center gap-6 text-center">
+          <h1 className="text-4xl font-semibold tracking-tight">
+            Webhooks Template
+          </h1>
+          <p className="text-muted-foreground">
+            Commet notifies, your app reacts. Provisioning, dunning UX, and
+            local entitlements kept in sync by webhook events.
+          </p>
+          <div className="flex gap-3">
+            <Button nativeButton={false} render={<Link href="/sign-up" />}>
+              Get started
+              <ArrowRight className="size-4" />
+            </Button>
+            <Button
+              variant="outline"
+              nativeButton={false}
+              render={<Link href="/pricing" />}
+            >
+              Pricing
+            </Button>
+          </div>
+        </section>
+
+        <section className="grid w-full max-w-2xl gap-4 md:grid-cols-3">
+          <FeatureCard
+            icon={Webhook}
+            title="Real-time sync"
+            description="Local billing state updated by subscription and payment events. See them arrive live in the dashboard."
+          />
+          <FeatureCard
+            icon={Bell}
+            title="Dunning UX"
+            description="Failed payments pause premium features with an in-app banner instead of a raw API error."
+          />
+          <FeatureCard
+            icon={Mail}
+            title="Lifecycle hooks"
+            description="Welcome email and team alerts fired from subscription.activated — the parts Commet leaves to you."
+          />
+        </section>
+      </main>
+
+      <footer className="border-t px-4 py-4 text-center text-xs text-muted-foreground">
+        Built with Commet, Better Auth, and Next.js.
+      </footer>
+    </div>
+  );
+}

--- a/examples/webhooks/app/pricing.md/route.ts
+++ b/examples/webhooks/app/pricing.md/route.ts
@@ -1,0 +1,9 @@
+import { PricingMarkdown } from "@commet/next";
+import { env } from "@/lib/env";
+
+export const GET = PricingMarkdown({
+  apiKey: env.COMMET_API_KEY,
+  title: "Webhooks SaaS Pricing",
+  description:
+    "Simple subscription pricing. Choose the plan that works for you. No hidden fees, no surprises.",
+});

--- a/examples/webhooks/app/pricing/page.tsx
+++ b/examples/webhooks/app/pricing/page.tsx
@@ -1,0 +1,146 @@
+import type { BillingInterval, Plan } from "@commet/node";
+
+type PlanFeatureItem = NonNullable<Plan["features"]>[number];
+
+import { Check } from "lucide-react";
+import { getPlansAction } from "@/actions/plans";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { getUser } from "@/lib/auth/session";
+import { getBillingStateForUser } from "@/lib/db/queries";
+import { checkoutAction } from "@/lib/payments/actions";
+
+function formatPrice(cents: number) {
+  return `$${(cents / 100).toFixed(0)}`;
+}
+
+function formatBillingInterval(interval: BillingInterval): string {
+  if (interval === "weekly") return "wk";
+  if (interval === "monthly") return "mo";
+  if (interval === "yearly") return "yr";
+  if (interval === "quarterly") return "qtr";
+  return interval;
+}
+
+function formatFeature(feature: PlanFeatureItem): string {
+  if (feature.type === "boolean" && feature.enabled) {
+    return feature.name;
+  }
+  if (feature.type === "usage" && feature.includedAmount !== null) {
+    return `${feature.includedAmount.toLocaleString()} ${feature.name} included`;
+  }
+  if (feature.type === "seats" && feature.includedAmount !== null) {
+    return `${feature.includedAmount} ${feature.name}`;
+  }
+  return feature.name;
+}
+
+export default async function PricingPage() {
+  const user = await getUser();
+  const billing = user ? await getBillingStateForUser(user.id) : null;
+  const hasLiveSubscription =
+    billing?.subscriptionStatus === "active" ||
+    billing?.subscriptionStatus === "trialing";
+
+  const plansResult = await getPlansAction();
+  const plans = plansResult.data || [];
+
+  return (
+    <div className="flex flex-1 flex-col items-center px-4 py-20">
+      <div className="mb-12 flex max-w-lg flex-col items-center gap-4 text-center">
+        <h1 className="text-3xl font-semibold tracking-tight">Pricing</h1>
+        <p className="text-muted-foreground">
+          Simple, fixed pricing. Choose the plan that works for you. No hidden
+          fees, no surprises.
+        </p>
+      </div>
+
+      {plans.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No plans available yet. Configure plans in your Commet dashboard.
+        </p>
+      ) : (
+        <div className="grid w-full max-w-2xl gap-6 md:grid-cols-2">
+          {plans.map((plan) => {
+            const defaultPrice =
+              plan.prices?.find((p) => p.isDefault) || plan.prices?.[0];
+            const isCurrentPlan =
+              hasLiveSubscription &&
+              billing?.planName?.toLowerCase() === plan.name.toLowerCase();
+
+            return (
+              <Card key={plan.id}>
+                <CardHeader>
+                  <CardTitle>{plan.name}</CardTitle>
+                  {plan.description && (
+                    <CardDescription>{plan.description}</CardDescription>
+                  )}
+                </CardHeader>
+                <CardContent className="flex flex-col gap-4">
+                  <div className="flex items-baseline gap-1">
+                    <span className="text-3xl font-semibold">
+                      {defaultPrice ? formatPrice(defaultPrice.price) : "Free"}
+                    </span>
+                    {defaultPrice && (
+                      <span className="text-sm text-muted-foreground">
+                        /
+                        {formatBillingInterval(
+                          defaultPrice.billingInterval || "monthly",
+                        )}
+                      </span>
+                    )}
+                  </div>
+                  <ul className="flex flex-col gap-2 text-sm">
+                    {plan.features?.map((feature) => (
+                      <li
+                        key={feature.code}
+                        className="flex items-center gap-2"
+                      >
+                        <Check className="size-4 text-muted-foreground" />
+                        <span>{formatFeature(feature)}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </CardContent>
+                <CardFooter>
+                  {isCurrentPlan ? (
+                    <Button type="button" className="w-full" disabled>
+                      Current plan
+                    </Button>
+                  ) : hasLiveSubscription ? (
+                    <Button
+                      className="w-full"
+                      nativeButton={false}
+                      render={
+                        <a
+                          href="/api/commet/portal"
+                          aria-label="Manage billing"
+                        >
+                          Manage billing
+                        </a>
+                      }
+                    />
+                  ) : (
+                    <form action={checkoutAction} className="w-full">
+                      <input type="hidden" name="planCode" value={plan.code} />
+                      <Button type="submit" className="w-full">
+                        Get started
+                      </Button>
+                    </form>
+                  )}
+                </CardFooter>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/webhooks/components.json
+++ b/examples/webhooks/components.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "base-nova",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "app/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "iconLibrary": "lucide",
+  "rtl": false,
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "menuColor": "default",
+  "menuAccent": "subtle",
+  "registries": {}
+}

--- a/examples/webhooks/components/auto-refresh.tsx
+++ b/examples/webhooks/components/auto-refresh.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export function AutoRefresh({ seconds }: { seconds: number }) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const interval = setInterval(() => router.refresh(), seconds * 1000);
+    return () => clearInterval(interval);
+  }, [router, seconds]);
+
+  return null;
+}

--- a/examples/webhooks/components/past-due-banner.tsx
+++ b/examples/webhooks/components/past-due-banner.tsx
@@ -1,0 +1,33 @@
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function PastDueBanner() {
+  return (
+    <div className="flex items-center justify-between gap-4 border-b border-destructive/30 bg-destructive/10 px-6 py-3">
+      <div className="flex items-center gap-2">
+        <AlertTriangle className="size-4 shrink-0 text-destructive" />
+        <p className="text-sm">
+          <span className="font-medium">Your last payment failed.</span>{" "}
+          <span className="text-muted-foreground">
+            Premium features are paused until payment succeeds.
+          </span>
+        </p>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        nativeButton={false}
+        render={
+          <a
+            href="/api/commet/portal"
+            aria-label="Update payment method"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Update payment method
+          </a>
+        }
+      />
+    </div>
+  );
+}

--- a/examples/webhooks/components/shared/sign-out-button.tsx
+++ b/examples/webhooks/components/shared/sign-out-button.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { LogOut } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { signOut } from "@/lib/auth/auth-client";
+
+export function SignOutButton() {
+  const router = useRouter();
+
+  return (
+    <button
+      type="button"
+      onClick={async () => {
+        await signOut();
+        router.push("/sign-in");
+      }}
+      className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-sm font-medium hover:bg-muted"
+    >
+      <LogOut className="size-4" />
+      Sign out
+    </button>
+  );
+}

--- a/examples/webhooks/components/shared/submit-button.tsx
+++ b/examples/webhooks/components/shared/submit-button.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import type { Button as ButtonPrimitive } from "@base-ui/react/button";
+import type { VariantProps } from "class-variance-authority";
+import { Loader2 } from "lucide-react";
+import type { ReactNode } from "react";
+import type { buttonVariants } from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
+
+interface SubmitButtonProps
+  extends ButtonPrimitive.Props,
+    VariantProps<typeof buttonVariants> {
+  isPending: boolean;
+  pendingText?: string;
+  icon?: ReactNode;
+}
+
+export function SubmitButton({
+  children,
+  isPending,
+  pendingText = "Saving...",
+  icon,
+  ...props
+}: SubmitButtonProps) {
+  return (
+    <Button type="submit" disabled={isPending} {...props}>
+      {isPending ? (
+        <>
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          {pendingText}
+        </>
+      ) : (
+        <>
+          {icon && <span className="mr-2">{icon}</span>}
+          {children}
+        </>
+      )}
+    </Button>
+  );
+}

--- a/examples/webhooks/components/template-header.tsx
+++ b/examples/webhooks/components/template-header.tsx
@@ -1,0 +1,69 @@
+import { ExternalLink, Github } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+
+function CommetLogo() {
+  return (
+    <svg width="18" height="18" viewBox="143 71 214 369" aria-label="Commet">
+      <path
+        d="M250 71L356.521 255.5H143.479L250 71Z"
+        className="fill-foreground"
+      />
+      <path
+        d="M250 440L356.521 255.5H143.479L250 440Z"
+        className="fill-foreground"
+      />
+      <rect
+        width="253.649"
+        height="17.0192"
+        transform="matrix(0.718749 0.695269 -0.64697 0.762515 143.458 243.867)"
+        className="fill-background"
+      />
+    </svg>
+  );
+}
+
+export function TemplateHeader({ templateName }: { templateName: string }) {
+  return (
+    <header className="sticky top-0 z-50 flex h-12 items-center justify-between border-b bg-background/80 px-4 backdrop-blur-sm">
+      <div className="flex items-center gap-3">
+        <Link
+          href="https://commet.co"
+          className="text-foreground hover:text-foreground/80"
+        >
+          <CommetLogo />
+        </Link>
+        <Separator orientation="vertical" className="h-4" />
+        <Link href="/" className="text-sm font-medium hover:text-foreground/80">
+          {templateName}
+        </Link>
+      </div>
+      <div className="flex items-center gap-1">
+        <Button
+          variant="ghost"
+          size="sm"
+          nativeButton={false}
+          render={<Link href="https://commet.co/docs" target="_blank" />}
+        >
+          Docs
+          <ExternalLink className="size-3 text-muted-foreground" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          nativeButton={false}
+          render={
+            <Link
+              href="https://github.com/commet-labs/commet"
+              target="_blank"
+              aria-label="GitHub"
+            />
+          }
+        >
+          <Github className="size-4" />
+        </Button>
+      </div>
+    </header>
+  );
+}

--- a/examples/webhooks/components/ui/avatar.tsx
+++ b/examples/webhooks/components/ui/avatar.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Avatar as AvatarPrimitive } from "@base-ui/react/avatar";
+
+import { cn } from "@/lib/utils";
+
+function Avatar({
+  className,
+  size = "default",
+  ...props
+}: AvatarPrimitive.Root.Props & {
+  size?: "default" | "sm" | "lg";
+}) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      data-size={size}
+      className={cn(
+        "group/avatar relative flex size-8 shrink-0 rounded-full select-none after:absolute after:inset-0 after:rounded-full after:border after:border-border after:mix-blend-darken data-[size=lg]:size-10 data-[size=sm]:size-6 dark:after:mix-blend-lighten",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarImage({ className, ...props }: AvatarPrimitive.Image.Props) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn(
+        "aspect-square size-full rounded-full object-cover",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: AvatarPrimitive.Fallback.Props) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "flex size-full items-center justify-center rounded-full bg-muted text-sm text-muted-foreground group-data-[size=sm]/avatar:text-xs",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Avatar, AvatarFallback, AvatarImage };

--- a/examples/webhooks/components/ui/button.tsx
+++ b/examples/webhooks/components/ui/button.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Button as ButtonPrimitive } from "@base-ui/react/button";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        outline:
+          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+        ghost:
+          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+        destructive:
+          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default:
+          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
+        icon: "size-8",
+        "icon-xs":
+          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm":
+          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+        "icon-lg": "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function Button({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+  return (
+    <ButtonPrimitive
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Button, buttonVariants };

--- a/examples/webhooks/components/ui/card.tsx
+++ b/examples/webhooks/components/ui/card.tsx
@@ -1,0 +1,103 @@
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Card({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        "font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-4 group-data-[size=sm]/card:px-3", className)}
+      {...props}
+    />
+  );
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+};

--- a/examples/webhooks/components/ui/form-field.tsx
+++ b/examples/webhooks/components/ui/form-field.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import type { ComponentProps } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+interface FormFieldProps extends ComponentProps<"input"> {
+  label: string;
+  error?: string;
+  description?: string;
+}
+
+export function FormField({
+  label,
+  error,
+  description,
+  id,
+  className,
+  ...props
+}: FormFieldProps) {
+  return (
+    <div className="space-y-1">
+      <Label htmlFor={id} className="mb-2">
+        {label}
+      </Label>
+      <Input
+        id={id}
+        className={cn(
+          error && "border-destructive focus-visible:ring-destructive/50",
+          className,
+        )}
+        {...props}
+      />
+      {description && !error && (
+        <p className="text-xs text-muted-foreground">{description}</p>
+      )}
+      {error && <p className="text-sm text-destructive-foreground">{error}</p>}
+    </div>
+  );
+}

--- a/examples/webhooks/components/ui/input.tsx
+++ b/examples/webhooks/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import { Input as InputPrimitive } from "@base-ui/react/input";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <InputPrimitive
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };

--- a/examples/webhooks/components/ui/label.tsx
+++ b/examples/webhooks/components/ui/label.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Label({ className, ...props }: React.ComponentProps<"label">) {
+  return (
+    // biome-ignore lint/a11y/noLabelWithoutControl: htmlFor passed via props
+    <label
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Label };

--- a/examples/webhooks/components/ui/separator.tsx
+++ b/examples/webhooks/components/ui/separator.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
+
+import { cn } from "@/lib/utils";
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  ...props
+}: SeparatorPrimitive.Props) {
+  return (
+    <SeparatorPrimitive
+      data-slot="separator"
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Separator };

--- a/examples/webhooks/components/ui/skeleton.tsx
+++ b/examples/webhooks/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils";
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/examples/webhooks/docker-compose.yml
+++ b/examples/webhooks/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: webhooks-saas-postgres
+    restart: unless-stopped
+    ports:
+      - "54328:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: webhooks_saas
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:
+    driver: local

--- a/examples/webhooks/drizzle.config.ts
+++ b/examples/webhooks/drizzle.config.ts
@@ -1,0 +1,18 @@
+import * as dotenv from "dotenv";
+import { defineConfig } from "drizzle-kit";
+
+dotenv.config();
+
+const postgresUrl = process.env.POSTGRES_URL;
+if (!postgresUrl) {
+  throw new Error("POSTGRES_URL is required");
+}
+
+export default defineConfig({
+  schema: "./lib/db/schema.ts",
+  out: "./drizzle",
+  dialect: "postgresql",
+  dbCredentials: {
+    url: postgresUrl,
+  },
+});

--- a/examples/webhooks/hooks/use-form-toast.ts
+++ b/examples/webhooks/hooks/use-form-toast.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+
+type ActionState = {
+  error?: string;
+  success?: string;
+  fieldErrors?: Record<string, string[] | undefined>;
+};
+
+export function useFormToast(state: ActionState) {
+  const prevStateRef = useRef<ActionState>(state);
+
+  useEffect(() => {
+    if (state === prevStateRef.current) return;
+    prevStateRef.current = state;
+
+    if (state.error) {
+      toast.error(state.error);
+    } else if (state.success) {
+      toast.success(state.success);
+    }
+  }, [state]);
+}

--- a/examples/webhooks/lib/auth/auth-client.ts
+++ b/examples/webhooks/lib/auth/auth-client.ts
@@ -1,0 +1,8 @@
+import { commetClient } from "@commet/better-auth/client";
+import { createAuthClient } from "better-auth/react";
+
+export const authClient = createAuthClient({
+  plugins: [commetClient()],
+});
+
+export const { signIn, signUp, signOut, useSession } = authClient;

--- a/examples/webhooks/lib/auth/auth.ts
+++ b/examples/webhooks/lib/auth/auth.ts
@@ -1,0 +1,40 @@
+import {
+  commet as commetPlugin,
+  features,
+  portal,
+  subscriptions,
+} from "@commet/better-auth";
+import { betterAuth } from "better-auth";
+import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { commet } from "../commet";
+import { db } from "../db/drizzle";
+import * as schema from "../db/schema";
+import { env } from "../env";
+
+export const auth = betterAuth({
+  database: drizzleAdapter(db, {
+    provider: "pg",
+    schema,
+  }),
+  emailAndPassword: {
+    enabled: true,
+    requireEmailVerification: false,
+  },
+  secret: env.BETTER_AUTH_SECRET,
+  baseURL: env.BETTER_AUTH_URL,
+  trustedOrigins: [env.BETTER_AUTH_URL],
+  plugins: [
+    commetPlugin({
+      client: commet,
+      createCustomerOnSignUp: true,
+      use: [
+        portal({ returnUrl: "/dashboard/billing" }),
+        subscriptions(),
+        features(),
+      ],
+    }),
+  ],
+});
+
+export type Session = typeof auth.$Infer.Session.session;
+export type User = typeof auth.$Infer.Session.user;

--- a/examples/webhooks/lib/auth/session.ts
+++ b/examples/webhooks/lib/auth/session.ts
@@ -1,0 +1,13 @@
+import { headers } from "next/headers";
+import { auth } from "./auth";
+
+export async function getSession() {
+  return auth.api.getSession({
+    headers: await headers(),
+  });
+}
+
+export async function getUser() {
+  const session = await getSession();
+  return session?.user || null;
+}

--- a/examples/webhooks/lib/billing/entitlements.ts
+++ b/examples/webhooks/lib/billing/entitlements.ts
@@ -1,0 +1,31 @@
+import type { BillingFeature } from "@/lib/db/schema";
+
+export interface DerivedAccess {
+  planLabel: string;
+  status: string;
+  features: BillingFeature[];
+}
+
+export function hasUsableSubscription(
+  status: string | null | undefined,
+): boolean {
+  return status === "active" || status === "trialing" || status === "past_due";
+}
+
+export function resolveAccessForBillingState(
+  state: {
+    planName: string | null;
+    subscriptionStatus: string | null;
+    features: BillingFeature[];
+  } | null,
+): DerivedAccess {
+  if (!state?.subscriptionStatus) {
+    return { planLabel: "Free", status: "none", features: [] };
+  }
+
+  return {
+    planLabel: state.planName ?? "Free",
+    status: state.subscriptionStatus,
+    features: state.features,
+  };
+}

--- a/examples/webhooks/lib/billing/sync.ts
+++ b/examples/webhooks/lib/billing/sync.ts
@@ -1,0 +1,224 @@
+import type { WebhookData } from "@commet/node";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db/drizzle";
+import { type BillingFeature, billingState, user } from "@/lib/db/schema";
+
+export function readExternalUserId(data: WebhookData): string | null {
+  const candidates = [
+    data.externalId,
+    data._customerExternalId,
+    data.customerId,
+  ];
+  return (
+    candidates.find(
+      (value): value is string => typeof value === "string" && value.length > 0,
+    ) ?? null
+  );
+}
+
+function requireExternalUserId(data: WebhookData): string {
+  const externalId = readExternalUserId(data);
+  if (!externalId) {
+    throw new Error(
+      `Webhook is missing externalId for customer ${data.customerId}. ` +
+        "This template expects customers created via better-auth signup.",
+    );
+  }
+  return externalId;
+}
+
+async function resolveLocalUser(data: WebhookData) {
+  const userId = requireExternalUserId(data);
+  const [localUser] = await db
+    .select({ id: user.id, email: user.email, name: user.name })
+    .from(user)
+    .where(eq(user.id, userId))
+    .limit(1);
+  if (!localUser) {
+    throw new Error(
+      `No local user found for externalId "${userId}" (customer ${data.customerId}).`,
+    );
+  }
+  return localUser;
+}
+
+function readPlanName(data: WebhookData): string | null {
+  const plan = data.plan;
+  if (
+    plan &&
+    typeof plan === "object" &&
+    "name" in plan &&
+    typeof (plan as { name?: unknown }).name === "string"
+  ) {
+    return (plan as { name: string }).name;
+  }
+  return null;
+}
+
+function isBillingFeature(value: unknown): value is BillingFeature {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "code" in value &&
+    "name" in value &&
+    "type" in value &&
+    typeof (value as { code?: unknown }).code === "string" &&
+    typeof (value as { name?: unknown }).name === "string" &&
+    typeof (value as { type?: unknown }).type === "string"
+  );
+}
+
+function readFeatures(data: WebhookData): BillingFeature[] {
+  return Array.isArray(data.features)
+    ? data.features.filter(isBillingFeature)
+    : [];
+}
+
+function readUsageRecorded(data: WebhookData): {
+  featureCode: string;
+  value: number;
+} {
+  const featureCode = data.featureCode;
+  const value = data.value;
+
+  if (typeof featureCode !== "string" || featureCode.length === 0) {
+    throw new Error(
+      `usage.recorded for customer ${data.customerId} is missing featureCode.`,
+    );
+  }
+
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(
+      `usage.recorded for customer ${data.customerId} is missing numeric value.`,
+    );
+  }
+
+  return { featureCode, value };
+}
+
+function applyUsageToFeatures(
+  features: BillingFeature[],
+  featureCode: string,
+  value: number,
+): BillingFeature[] {
+  return features.map((feature) => {
+    if (feature.code !== featureCode || feature.type !== "usage") {
+      return feature;
+    }
+
+    const current = (feature.current ?? 0) + value;
+    const remaining =
+      typeof feature.remaining === "number"
+        ? Math.max(feature.remaining - value, 0)
+        : feature.remaining;
+    const overageQuantity =
+      typeof feature.included === "number"
+        ? Math.max(current - feature.included, 0)
+        : feature.overageQuantity;
+
+    return {
+      ...feature,
+      current,
+      remaining,
+      overageQuantity,
+      billedQuantity: Math.max(feature.billedQuantity ?? 0, current),
+    };
+  });
+}
+
+export async function syncBillingStateFromSnapshot(data: WebhookData) {
+  const localUser = await resolveLocalUser(data);
+
+  const status: string | undefined = data.status;
+  if (typeof status !== "string") {
+    throw new Error(
+      `customer.state_changed for customer ${data.customerId} is missing status.`,
+    );
+  }
+
+  const hasNoSubscription = status === "none" || status === "canceled";
+  const syncedState = {
+    planName: readPlanName(data),
+    subscriptionStatus: status,
+    subscriptionId:
+      typeof data.subscriptionId === "string" ? data.subscriptionId : null,
+    billingInterval:
+      typeof data.billingInterval === "string" ? data.billingInterval : null,
+    features: readFeatures(data),
+    ...(hasNoSubscription ? { currentPeriodEnd: null } : {}),
+    updatedAt: new Date(),
+  };
+
+  await db
+    .insert(billingState)
+    .values({ userId: localUser.id, ...syncedState })
+    .onConflictDoUpdate({ target: billingState.userId, set: syncedState });
+}
+
+export async function recordUsageFromEvent(data: WebhookData) {
+  const localUser = await resolveLocalUser(data);
+  const { featureCode, value } = readUsageRecorded(data);
+
+  const [state] = await db
+    .select({ features: billingState.features })
+    .from(billingState)
+    .where(eq(billingState.userId, localUser.id))
+    .limit(1);
+
+  if (!state) {
+    throw new Error(
+      `usage.recorded webhook for user ${localUser.id} but no billing state exists. ` +
+        "Expected customer.state_changed to have been processed first.",
+    );
+  }
+
+  await db
+    .update(billingState)
+    .set({
+      features: applyUsageToFeatures(state.features, featureCode, value),
+      updatedAt: new Date(),
+    })
+    .where(eq(billingState.userId, localUser.id));
+}
+
+export async function resolveActivatedUserForWelcome(data: WebhookData) {
+  const localUser = await resolveLocalUser(data);
+  const planName = readPlanName(data);
+  if (!planName) {
+    throw new Error(
+      `subscription_activated snapshot for customer ${data.customerId} is missing plan.name.`,
+    );
+  }
+  return {
+    userId: localUser.id,
+    userEmail: localUser.email,
+    userName: localUser.name,
+    planName,
+  };
+}
+
+export async function recordCurrentPeriod(data: WebhookData) {
+  const localUser = await resolveLocalUser(data);
+  const currentPeriodEnd =
+    typeof data.currentPeriodEnd === "string"
+      ? new Date(data.currentPeriodEnd)
+      : null;
+
+  await db
+    .update(billingState)
+    .set({ currentPeriodEnd, updatedAt: new Date() })
+    .where(eq(billingState.userId, localUser.id));
+}
+
+export async function restoreAccessAfterPayment(data: WebhookData) {
+  const localUser = await resolveLocalUser(data);
+  await db
+    .update(billingState)
+    .set({ subscriptionStatus: "active", updatedAt: new Date() })
+    .where(
+      and(
+        eq(billingState.userId, localUser.id),
+        eq(billingState.subscriptionStatus, "past_due"),
+      ),
+    );
+}

--- a/examples/webhooks/lib/billing/webhook-events.ts
+++ b/examples/webhooks/lib/billing/webhook-events.ts
@@ -1,0 +1,89 @@
+import type { WebhookPayload } from "@commet/node";
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db/drizzle";
+import { user, webhookEvents } from "@/lib/db/schema";
+import { readExternalUserId } from "./sync";
+
+const staleProcessingWindowMs = 5 * 60 * 1000;
+
+export async function recordWebhookEvent({
+  eventId,
+  payload,
+}: {
+  eventId: string;
+  payload: WebhookPayload;
+}): Promise<"inserted" | "completed" | "processing" | "retry"> {
+  const externalUserId = readExternalUserId(payload.data);
+  let localUserId: string | null = null;
+
+  if (externalUserId) {
+    const [localUser] = await db
+      .select({ id: user.id })
+      .from(user)
+      .where(eq(user.id, externalUserId))
+      .limit(1);
+    localUserId = localUser?.id ?? null;
+  }
+
+  const [inserted] = await db
+    .insert(webhookEvents)
+    .values({
+      eventId,
+      event: payload.event,
+      commetCustomerId: payload.data.customerId ?? null,
+      userId: localUserId,
+      payload,
+    })
+    .onConflictDoNothing({ target: webhookEvents.eventId })
+    .returning({ id: webhookEvents.id, status: webhookEvents.status });
+
+  if (inserted) {
+    return "inserted";
+  }
+
+  const [existing] = await db
+    .select({
+      status: webhookEvents.status,
+      updatedAt: webhookEvents.updatedAt,
+    })
+    .from(webhookEvents)
+    .where(eq(webhookEvents.eventId, eventId))
+    .limit(1);
+
+  if (existing?.status === "completed") {
+    return "completed";
+  }
+
+  const updatedAt = existing?.updatedAt;
+  if (
+    existing?.status === "processing" &&
+    updatedAt &&
+    Date.now() - updatedAt.getTime() < staleProcessingWindowMs
+  ) {
+    return "processing";
+  }
+
+  await db
+    .update(webhookEvents)
+    .set({ status: "processing", updatedAt: new Date() })
+    .where(eq(webhookEvents.eventId, eventId));
+  return "retry";
+}
+
+export async function markWebhookEventCompleted(eventId: string) {
+  await db
+    .update(webhookEvents)
+    .set({
+      status: "completed",
+      processedAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .where(eq(webhookEvents.eventId, eventId));
+}
+
+export async function markWebhookEventFailed(eventId: string) {
+  await db
+    .update(webhookEvents)
+    .set({ status: "failed", updatedAt: new Date() })
+    .where(eq(webhookEvents.eventId, eventId));
+}

--- a/examples/webhooks/lib/commet.ts
+++ b/examples/webhooks/lib/commet.ts
@@ -1,0 +1,6 @@
+import { Commet } from "@commet/node";
+import { env } from "@/lib/env";
+
+export const commet = new Commet({
+  apiKey: env.COMMET_API_KEY,
+});

--- a/examples/webhooks/lib/db/drizzle.ts
+++ b/examples/webhooks/lib/db/drizzle.ts
@@ -1,0 +1,10 @@
+import dotenv from "dotenv";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { env } from "@/lib/env";
+import * as schema from "./schema";
+
+dotenv.config();
+
+export const client = postgres(env.POSTGRES_URL);
+export const db = drizzle(client, { schema });

--- a/examples/webhooks/lib/db/queries.ts
+++ b/examples/webhooks/lib/db/queries.ts
@@ -1,0 +1,67 @@
+import { desc, eq } from "drizzle-orm";
+import { getUser as getAuthUser } from "@/lib/auth/session";
+import { db } from "./drizzle";
+import {
+  activityLogs,
+  type BillingState,
+  billingState,
+  user,
+  webhookEvents,
+} from "./schema";
+
+export async function getUser() {
+  return getAuthUser();
+}
+
+export async function getBillingStateForUser(
+  userId: string,
+): Promise<BillingState | null> {
+  const [stateRow] = await db
+    .select()
+    .from(billingState)
+    .where(eq(billingState.userId, userId))
+    .limit(1);
+
+  return stateRow ?? null;
+}
+
+export async function getRecentWebhookEvents() {
+  const currentUser = await getUser();
+  if (!currentUser) {
+    throw new Error("User not authenticated");
+  }
+
+  return await db
+    .select({
+      id: webhookEvents.id,
+      event: webhookEvents.event,
+      commetCustomerId: webhookEvents.commetCustomerId,
+      payload: webhookEvents.payload,
+      receivedAt: webhookEvents.receivedAt,
+    })
+    .from(webhookEvents)
+    .where(eq(webhookEvents.userId, currentUser.id))
+    .orderBy(desc(webhookEvents.receivedAt), desc(webhookEvents.id))
+    .limit(50);
+}
+
+export async function getActivityLogs() {
+  const currentUser = await getUser();
+  if (!currentUser) {
+    throw new Error("User not authenticated");
+  }
+
+  return await db
+    .select({
+      id: activityLogs.id,
+      action: activityLogs.action,
+      timestamp: activityLogs.timestamp,
+      ipAddress: activityLogs.ipAddress,
+      userName: user.name,
+    })
+    .from(activityLogs)
+    .leftJoin(user, eq(activityLogs.userId, user.id))
+    .where(eq(activityLogs.userId, currentUser.id))
+    .orderBy(desc(activityLogs.timestamp))
+    .limit(10);
+}

--- a/examples/webhooks/lib/db/schema.ts
+++ b/examples/webhooks/lib/db/schema.ts
@@ -1,0 +1,174 @@
+import { relations } from "drizzle-orm";
+import {
+  boolean,
+  jsonb,
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  uniqueIndex,
+  varchar,
+} from "drizzle-orm/pg-core";
+
+export interface BillingFeature {
+  code: string;
+  name: string;
+  type: string;
+  allowed: boolean;
+  enabled: boolean | null;
+  current: number | null;
+  included: number | null;
+  remaining: number | null;
+  overageQuantity: number | null;
+  overageUnitPrice: number | null;
+  unlimited: boolean | null;
+  overageEnabled: boolean | null;
+  billedQuantity: number | null;
+}
+
+export const user = pgTable("user", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  email: text("email").notNull().unique(),
+  emailVerified: boolean("emailVerified").notNull().default(false),
+  image: text("image"),
+  createdAt: timestamp("createdAt").notNull().defaultNow(),
+  updatedAt: timestamp("updatedAt").notNull().defaultNow(),
+});
+
+export const session = pgTable("session", {
+  id: text("id").primaryKey(),
+  expiresAt: timestamp("expiresAt").notNull(),
+  token: text("token").notNull().unique(),
+  createdAt: timestamp("createdAt").notNull().defaultNow(),
+  updatedAt: timestamp("updatedAt").notNull().defaultNow(),
+  ipAddress: text("ipAddress"),
+  userAgent: text("userAgent"),
+  userId: text("userId")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+});
+
+export const account = pgTable("account", {
+  id: text("id").primaryKey(),
+  accountId: text("accountId").notNull(),
+  providerId: text("providerId").notNull(),
+  userId: text("userId")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  accessToken: text("accessToken"),
+  refreshToken: text("refreshToken"),
+  idToken: text("idToken"),
+  accessTokenExpiresAt: timestamp("accessTokenExpiresAt"),
+  refreshTokenExpiresAt: timestamp("refreshTokenExpiresAt"),
+  scope: text("scope"),
+  password: text("password"),
+  createdAt: timestamp("createdAt").notNull().defaultNow(),
+  updatedAt: timestamp("updatedAt").notNull().defaultNow(),
+});
+
+export const verification = pgTable("verification", {
+  id: text("id").primaryKey(),
+  identifier: text("identifier").notNull(),
+  value: text("value").notNull(),
+  expiresAt: timestamp("expiresAt").notNull(),
+  createdAt: timestamp("createdAt").defaultNow(),
+  updatedAt: timestamp("updatedAt").defaultNow(),
+});
+
+export const activityLogs = pgTable("activity_logs", {
+  id: serial("id").primaryKey(),
+  userId: text("user_id").references(() => user.id),
+  action: text("action").notNull(),
+  timestamp: timestamp("timestamp").notNull().defaultNow(),
+  ipAddress: varchar("ip_address", { length: 45 }),
+});
+
+export const billingState = pgTable("billing_state", {
+  userId: text("user_id")
+    .primaryKey()
+    .references(() => user.id, { onDelete: "cascade" }),
+  planName: text("plan_name"),
+  subscriptionId: text("subscription_id"),
+  subscriptionStatus: text("subscription_status"),
+  billingInterval: text("billing_interval"),
+  features: jsonb("features").$type<BillingFeature[]>().notNull().default([]),
+  currentPeriodEnd: timestamp("current_period_end"),
+  updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});
+
+export const webhookEvents = pgTable(
+  "webhook_events",
+  {
+    id: serial("id").primaryKey(),
+    eventId: text("event_id"),
+    event: text("event").notNull(),
+    status: text("status").notNull().default("processing"),
+    commetCustomerId: text("commet_customer_id"),
+    userId: text("user_id").references(() => user.id, { onDelete: "set null" }),
+    payload: jsonb("payload").notNull(),
+    processedAt: timestamp("processed_at"),
+    receivedAt: timestamp("received_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [uniqueIndex("webhook_events_event_id_idx").on(table.eventId)],
+);
+
+export const userRelations = relations(user, ({ many, one }) => ({
+  sessions: many(session),
+  accounts: many(account),
+  activityLogs: many(activityLogs),
+  billingState: one(billingState),
+}));
+
+export const billingStateRelations = relations(billingState, ({ one }) => ({
+  user: one(user, {
+    fields: [billingState.userId],
+    references: [user.id],
+  }),
+}));
+
+export const webhookEventsRelations = relations(webhookEvents, ({ one }) => ({
+  user: one(user, {
+    fields: [webhookEvents.userId],
+    references: [user.id],
+  }),
+}));
+
+export const sessionRelations = relations(session, ({ one }) => ({
+  user: one(user, {
+    fields: [session.userId],
+    references: [user.id],
+  }),
+}));
+
+export const accountRelations = relations(account, ({ one }) => ({
+  user: one(user, {
+    fields: [account.userId],
+    references: [user.id],
+  }),
+}));
+
+export const activityLogsRelations = relations(activityLogs, ({ one }) => ({
+  user: one(user, {
+    fields: [activityLogs.userId],
+    references: [user.id],
+  }),
+}));
+
+export type User = typeof user.$inferSelect;
+export type NewUser = typeof user.$inferInsert;
+export type Session = typeof session.$inferSelect;
+export type Account = typeof account.$inferSelect;
+export type ActivityLog = typeof activityLogs.$inferSelect;
+export type NewActivityLog = typeof activityLogs.$inferInsert;
+export type BillingState = typeof billingState.$inferSelect;
+export type WebhookEventRecord = typeof webhookEvents.$inferSelect;
+
+export enum ActivityType {
+  SIGN_UP = "SIGN_UP",
+  SIGN_IN = "SIGN_IN",
+  SIGN_OUT = "SIGN_OUT",
+  UPDATE_PASSWORD = "UPDATE_PASSWORD",
+  UPDATE_ACCOUNT = "UPDATE_ACCOUNT",
+}

--- a/examples/webhooks/lib/env.ts
+++ b/examples/webhooks/lib/env.ts
@@ -1,0 +1,25 @@
+import "server-only";
+
+import { z } from "zod";
+
+const optionalNonEmptyString = z.preprocess(
+  (value) => (value === "" ? undefined : value),
+  z.string().min(1).optional(),
+);
+
+const envSchema = z.object({
+  POSTGRES_URL: z.string().min(1, "POSTGRES_URL is required"),
+  BETTER_AUTH_SECRET: z
+    .string()
+    .min(32, "BETTER_AUTH_SECRET must be at least 32 characters"),
+  BETTER_AUTH_URL: z.string().url("BETTER_AUTH_URL must be a valid URL"),
+  COMMET_API_KEY: z.string().min(1, "COMMET_API_KEY is required"),
+  COMMET_WEBHOOK_SECRET: z.string().min(1, "COMMET_WEBHOOK_SECRET is required"),
+  NEXT_PUBLIC_APP_URL: z
+    .string()
+    .url("NEXT_PUBLIC_APP_URL must be a valid URL"),
+  RESEND_API_KEY: optionalNonEmptyString,
+  EMAIL_FROM: optionalNonEmptyString,
+});
+
+export const env = envSchema.parse(process.env);

--- a/examples/webhooks/lib/notifications/email.ts
+++ b/examples/webhooks/lib/notifications/email.ts
@@ -1,0 +1,50 @@
+import { Resend } from "resend";
+import { env } from "@/lib/env";
+
+interface WelcomeEmailParams {
+  userId: string;
+  userEmail: string;
+  userName: string;
+  planName: string;
+}
+
+export async function sendWelcomeEmail({
+  userId,
+  userEmail,
+  userName,
+  planName,
+}: WelcomeEmailParams) {
+  if (!env.RESEND_API_KEY || !env.EMAIL_FROM) {
+    console.warn(
+      "[email] RESEND_API_KEY or EMAIL_FROM not set; skipping welcome email",
+    );
+    return;
+  }
+
+  const resend = new Resend(env.RESEND_API_KEY);
+  const { data, error } = await resend.emails.send(
+    {
+      from: env.EMAIL_FROM,
+      to: [userEmail],
+      subject: `Welcome to ${planName}`,
+      html: `
+        <div style="font-family: 'IBM Plex Sans', -apple-system, sans-serif; max-width: 480px; margin: 0 auto; padding: 32px 24px; color: #171717;">
+          <h1 style="font-size: 20px; font-weight: 600; margin: 0 0 16px;">Welcome to ${planName}, ${userName}</h1>
+          <p style="font-size: 14px; line-height: 1.6; margin: 0 0 24px; color: #404040;">
+            Your subscription is active. Advanced analytics and your new project limits are already unlocked in the dashboard.
+          </p>
+          <a href="${env.NEXT_PUBLIC_APP_URL}/dashboard" style="display: inline-block; background: #171717; color: #fafafa; font-size: 14px; font-weight: 500; padding: 10px 20px; text-decoration: none;">
+            Go to dashboard
+          </a>
+        </div>
+      `,
+    },
+    { idempotencyKey: `welcome-email/${userId}` },
+  );
+
+  if (error) {
+    console.error(`[email] Failed to send welcome email: ${error.message}`);
+    return;
+  }
+  console.log(`[email] Welcome email sent to ${userEmail} (${data?.id})`);
+}

--- a/examples/webhooks/lib/notifications/team.ts
+++ b/examples/webhooks/lib/notifications/team.ts
@@ -1,0 +1,11 @@
+interface NewSubscriptionNotification {
+  userEmail: string;
+  planName: string;
+}
+
+export async function notifyTeamOfNewSubscription({
+  userEmail,
+  planName,
+}: NewSubscriptionNotification) {
+  console.log(`[team] 💰 New ${planName} subscription: ${userEmail}`);
+}

--- a/examples/webhooks/lib/payments/actions.ts
+++ b/examples/webhooks/lib/payments/actions.ts
@@ -1,0 +1,64 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { getUser } from "@/lib/auth/session";
+import { env } from "@/lib/env";
+import { getCheckoutUrl } from "@/lib/payments/commet";
+import { normalizePlanCode } from "@/lib/plans";
+import { buildInternalHref } from "@/lib/redirects";
+
+export async function checkoutAction(formData: FormData) {
+  const planCode = normalizePlanCode(formData.get("planCode"));
+  if (!planCode) {
+    redirect("/pricing?error=missing_plan");
+  }
+
+  const user = await getUser();
+  if (!user) {
+    redirect(buildInternalHref("/sign-up", { planCode }));
+  }
+
+  redirect(buildInternalHref("/checkout", { planCode }));
+}
+
+export async function handlePostSignupCheckout(planCode: string) {
+  "use server";
+
+  const user = await getUser();
+
+  if (!user) {
+    return { success: false, error: "User not authenticated" } as const;
+  }
+
+  const successUrl = `${env.NEXT_PUBLIC_APP_URL}/dashboard`;
+
+  try {
+    const checkoutUrl = await getCheckoutUrl({ planCode, successUrl });
+    return { success: true, checkoutUrl } as const;
+  } catch (error) {
+    console.error("Failed to get checkout URL:", error);
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unable to start checkout. Please try again.",
+    } as const;
+  }
+}
+
+export async function customerPortalAction() {
+  const user = await getUser();
+  if (!user) {
+    redirect("/sign-in");
+  }
+
+  const { commet } = await import("@/lib/commet");
+  const portalResult = await commet.portal.getUrl({ customerId: user.id });
+
+  if (!portalResult.success || !portalResult.data?.portalUrl) {
+    redirect("/dashboard/billing");
+  }
+
+  redirect(portalResult.data.portalUrl);
+}

--- a/examples/webhooks/lib/payments/commet.ts
+++ b/examples/webhooks/lib/payments/commet.ts
@@ -1,0 +1,108 @@
+import { redirect } from "next/navigation";
+import { getUser } from "@/lib/auth/session";
+import { commet } from "@/lib/commet";
+import { normalizePlanCode } from "@/lib/plans";
+import { buildInternalHref } from "@/lib/redirects";
+
+export async function createCheckoutSession({
+  planCode,
+  successUrl,
+}: {
+  planCode: string;
+  successUrl?: string;
+}) {
+  const normalizedPlanCode = normalizePlanCode(planCode);
+  if (!normalizedPlanCode) {
+    redirect("/pricing?error=missing_plan");
+  }
+
+  const user = await getUser();
+
+  if (!user) {
+    redirect(
+      buildInternalHref("/sign-up", {
+        redirect: "/checkout",
+        planCode: normalizedPlanCode,
+      }),
+    );
+  }
+
+  const existing = await commet.subscriptions.getActive({
+    customerId: user.id,
+  });
+
+  if (existing.success && existing.data) {
+    const status = existing.data.status;
+
+    if (status === "active" || status === "trialing") {
+      redirect("/dashboard/billing?error=already_subscribed");
+    }
+
+    if (status === "pending_payment" && existing.data.checkoutUrl) {
+      redirect(existing.data.checkoutUrl);
+    }
+  }
+
+  const result = await commet.subscriptions.create({
+    customerId: user.id,
+    planCode: normalizedPlanCode,
+    successUrl,
+  });
+
+  if (!result.success || !result.data?.checkoutUrl) {
+    throw new Error(
+      result.error?.message || "Failed to create checkout session",
+    );
+  }
+
+  redirect(result.data.checkoutUrl);
+}
+
+export async function getCheckoutUrl({
+  planCode,
+  successUrl,
+}: {
+  planCode: string;
+  successUrl?: string;
+}): Promise<string> {
+  const normalizedPlanCode = normalizePlanCode(planCode);
+  if (!normalizedPlanCode) {
+    throw new Error("Missing plan code");
+  }
+
+  const user = await getUser();
+
+  if (!user) {
+    throw new Error("User not authenticated");
+  }
+
+  const existing = await commet.subscriptions.getActive({
+    customerId: user.id,
+  });
+
+  if (existing.success && existing.data) {
+    const status = existing.data.status;
+
+    if (status === "active" || status === "trialing") {
+      throw new Error("User already has active subscription");
+    }
+
+    if (status === "pending_payment" && existing.data.checkoutUrl) {
+      return existing.data.checkoutUrl;
+    }
+  }
+
+  const result = await commet.subscriptions.create({
+    customerId: user.id,
+    planCode: normalizedPlanCode,
+    successUrl,
+  });
+
+  if (!result.success || !result.data?.checkoutUrl) {
+    throw new Error(
+      result.error?.message || "Failed to create checkout session",
+    );
+  }
+
+  return result.data.checkoutUrl;
+}

--- a/examples/webhooks/lib/plans.ts
+++ b/examples/webhooks/lib/plans.ts
@@ -1,0 +1,14 @@
+const planCodePattern = /^[a-z0-9_]+$/;
+
+export function normalizePlanCode(value: FormDataEntryValue | string | null) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const planCode = value.trim();
+  if (!planCodePattern.test(planCode)) {
+    return null;
+  }
+
+  return planCode;
+}

--- a/examples/webhooks/lib/redirects.ts
+++ b/examples/webhooks/lib/redirects.ts
@@ -1,0 +1,29 @@
+const allowedRedirectPaths = new Set(["/dashboard", "/pricing", "/checkout"]);
+
+export function safeRedirectPath(value: string | null): string {
+  if (!value) {
+    return "/dashboard";
+  }
+
+  const pathname = value.trim();
+  if (!allowedRedirectPaths.has(pathname)) {
+    return "/dashboard";
+  }
+
+  return pathname;
+}
+
+export function buildInternalHref(
+  pathname: string,
+  params: Record<string, string | null | undefined>,
+) {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value) {
+      searchParams.set(key, value);
+    }
+  }
+
+  const query = searchParams.toString();
+  return query ? `${pathname}?${query}` : pathname;
+}

--- a/examples/webhooks/lib/utils.ts
+++ b/examples/webhooks/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/examples/webhooks/lib/validations/auth.ts
+++ b/examples/webhooks/lib/validations/auth.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+export const signInSchema = z.object({
+  email: z.string().email("Please enter a valid email address"),
+  password: z.string().min(8, "Password must be at least 8 characters"),
+});
+
+export const signUpSchema = z.object({
+  email: z.string().email("Please enter a valid email address"),
+  password: z.string().min(8, "Password must be at least 8 characters"),
+  name: z.string().optional(),
+});
+
+export const updateAccountSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  email: z.string().email("Please enter a valid email address"),
+});
+
+export const updatePasswordSchema = z
+  .object({
+    currentPassword: z
+      .string()
+      .min(8, "Password must be at least 8 characters"),
+    newPassword: z.string().min(8, "Password must be at least 8 characters"),
+    confirmPassword: z
+      .string()
+      .min(8, "Password must be at least 8 characters"),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: "New password and confirmation do not match",
+    path: ["confirmPassword"],
+  });
+
+export type SignInInput = z.infer<typeof signInSchema>;
+export type SignUpInput = z.infer<typeof signUpSchema>;

--- a/examples/webhooks/next.config.ts
+++ b/examples/webhooks/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/examples/webhooks/package.json
+++ b/examples/webhooks/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "webhooks-example",
+  "private": true,
+  "scripts": {
+    "dev": "drizzle-kit push && next dev --port 3008 --turbopack",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf .turbo node_modules .next",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:push": "drizzle-kit push",
+    "db:studio": "drizzle-kit studio"
+  },
+  "dependencies": {
+    "@base-ui/react": "^1.3.0",
+    "@commet/better-auth": "7.0.0",
+    "@commet/next": "1.0.11",
+    "@commet/node": "7.3.0",
+    "@radix-ui/react-slot": "1.2.5",
+    "@vercel/analytics": "^2.0.1",
+    "better-auth": "1.6.16",
+    "class-variance-authority": "0.7.1",
+    "clsx": "2.1.1",
+    "dotenv": "17.4.2",
+    "drizzle-orm": "0.45.2",
+    "lucide-react": "0.577.0",
+    "next": "16.2.9",
+    "postgres": "3.4.9",
+    "radix-ui": "1.5.0",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
+    "resend": "6.12.4",
+    "server-only": "0.0.1",
+    "shadcn": "^4.1.1",
+    "sonner": "2.0.7",
+    "tailwind-merge": "3.6.0",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "4.3.0",
+    "@types/node": "24.13.1",
+    "@types/react": "19.2.17",
+    "@types/react-dom": "19.2.3",
+    "drizzle-kit": "0.31.10",
+    "tailwindcss": "4.3.0",
+    "tw-animate-css": "1.4.0",
+    "typescript": "5.9.3"
+  },
+  "packageManager": "pnpm@10.28.0"
+}

--- a/examples/webhooks/package.json
+++ b/examples/webhooks/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@base-ui/react": "^1.3.0",
     "@commet/better-auth": "7.0.0",
-    "@commet/next": "1.0.11",
+    "@commet/next": "1.1.0",
     "@commet/node": "7.3.0",
     "@radix-ui/react-slot": "1.2.5",
     "@vercel/analytics": "^2.0.1",

--- a/examples/webhooks/postcss.config.mjs
+++ b/examples/webhooks/postcss.config.mjs
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};

--- a/examples/webhooks/public/favicon-dark.svg
+++ b/examples/webhooks/public/favicon-dark.svg
@@ -1,0 +1,6 @@
+<svg width="500" height="500" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 0H500V500H0V0Z" fill="black"/>
+<path d="M250 71L356.521 255.5H143.479L250 71Z" fill="white"/>
+<path d="M250 440L356.521 255.5H143.479L250 440Z" fill="white"/>
+<rect width="253.649" height="17.0192" transform="matrix(0.718749 0.695269 -0.64697 0.762515 143.458 243.867)" fill="black"/>
+</svg>

--- a/examples/webhooks/public/favicon-light.svg
+++ b/examples/webhooks/public/favicon-light.svg
@@ -1,0 +1,6 @@
+<svg width="500" height="500" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 0H500V500H0V0Z" fill="white"/>
+<path d="M250 71L356.521 255.5H143.479L250 71Z" fill="black"/>
+<path d="M250 440L356.521 255.5H143.479L250 440Z" fill="black"/>
+<rect width="253.649" height="17.0192" transform="matrix(0.718749 0.695269 -0.64697 0.762515 143.458 243.867)" fill="white"/>
+</svg>

--- a/examples/webhooks/tsconfig.json
+++ b/examples/webhooks/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
+    "**/*.mts",
+    ".commet/types.d.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/examples/webhooks/vercel.json
+++ b/examples/webhooks/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "dependabot/**": false
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -691,8 +691,8 @@ importers:
         specifier: 7.0.0
         version: 7.0.0(@commet/node@7.3.0(typescript@5.9.3))(better-auth@1.6.16(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.2)(postgres@3.4.9))(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8))(better-call@1.3.6(zod@4.4.3))(zod@4.4.3)
       '@commet/next':
-        specifier: 1.0.11
-        version: 1.0.11(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
+        specifier: 1.1.0
+        version: 1.1.0(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
       '@commet/node':
         specifier: 7.3.0
         version: 7.3.0(typescript@5.9.3)
@@ -1292,8 +1292,8 @@ packages:
       better-call: '>=1.3.2'
       zod: '>=3.24.2'
 
-  '@commet/next@1.0.11':
-    resolution: {integrity: sha512-2K2wJ8tVmI/zcTw8zNSKbf2OnS8htvVEcIqpINYtklgZZYsgDkCDF2YtxtI2hJCcuYExHrEgT/xzwVF3NSawxA==}
+  '@commet/next@1.1.0':
+    resolution: {integrity: sha512-wX0EZEWax2bMvnf5+dHaiweuQ3cTge8nPDERHzyYJ36PYlVjK3Pwc21V+IB29gHcg544O+iZIfpYorruqE78+w==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       next: '>=16.0.0'
@@ -6533,7 +6533,7 @@ snapshots:
       better-call: 1.3.6(zod@4.4.3)
       zod: 4.4.3
 
-  '@commet/next@1.0.11(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)':
+  '@commet/next@1.1.0(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)':
     dependencies:
       '@commet/node': 7.3.0(typescript@5.9.3)
       next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -682,6 +682,103 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  examples/webhooks:
+    dependencies:
+      '@base-ui/react':
+        specifier: ^1.3.0
+        version: 1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@commet/better-auth':
+        specifier: 7.0.0
+        version: 7.0.0(@commet/node@7.3.0(typescript@5.9.3))(better-auth@1.6.16(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.2)(postgres@3.4.9))(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8))(better-call@1.3.6(zod@4.4.3))(zod@4.4.3)
+      '@commet/next':
+        specifier: 1.0.11
+        version: 1.0.11(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
+      '@commet/node':
+        specifier: 7.3.0
+        version: 7.3.0(typescript@5.9.3)
+      '@radix-ui/react-slot':
+        specifier: 1.2.5
+        version: 1.2.5(@types/react@19.2.17)(react@19.2.7)
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      better-auth:
+        specifier: 1.6.16
+        version: 1.6.16(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.2)(postgres@3.4.9))(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8)
+      class-variance-authority:
+        specifier: 0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: 2.1.1
+        version: 2.1.1
+      dotenv:
+        specifier: 17.4.2
+        version: 17.4.2
+      drizzle-orm:
+        specifier: 0.45.2
+        version: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.2)(postgres@3.4.9)
+      lucide-react:
+        specifier: 0.577.0
+        version: 0.577.0(react@19.2.7)
+      next:
+        specifier: 16.2.9
+        version: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      postgres:
+        specifier: 3.4.9
+        version: 3.4.9
+      radix-ui:
+        specifier: 1.5.0
+        version: 1.5.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
+      resend:
+        specifier: 6.12.4
+        version: 6.12.4
+      server-only:
+        specifier: 0.0.1
+        version: 0.0.1
+      shadcn:
+        specifier: ^4.1.1
+        version: 4.11.0(typescript@5.9.3)
+      sonner:
+        specifier: 2.0.7
+        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      tailwind-merge:
+        specifier: 3.6.0
+        version: 3.6.0
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@tailwindcss/postcss':
+        specifier: 4.3.0
+        version: 4.3.0
+      '@types/node':
+        specifier: 24.13.1
+        version: 24.13.1
+      '@types/react':
+        specifier: 19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      drizzle-kit:
+        specifier: 0.31.10
+        version: 0.31.10
+      tailwindcss:
+        specifier: 4.3.0
+        version: 4.3.0
+      tw-animate-css:
+        specifier: 1.4.0
+        version: 1.4.0
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
   packages/ai-sdk:
     devDependencies:
       '@ai-sdk/provider':
@@ -1185,6 +1282,27 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@commet/better-auth@7.0.0':
+    resolution: {integrity: sha512-robsxoBv7JtOwFE4fyymB/FIKfJBIMUd7W7G3I3usLi+cwdjGNdT35tuLgPHIbt/1VXv/FIjKHIpv/OQ+EKKBA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@commet/node': ^7.0.0
+      better-auth: '>=1.5.6'
+      better-call: '>=1.3.2'
+      zod: '>=3.24.2'
+
+  '@commet/next@1.0.11':
+    resolution: {integrity: sha512-2K2wJ8tVmI/zcTw8zNSKbf2OnS8htvVEcIqpINYtklgZZYsgDkCDF2YtxtI2hJCcuYExHrEgT/xzwVF3NSawxA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      next: '>=16.0.0'
+
+  '@commet/node@7.3.0':
+    resolution: {integrity: sha512-dhDwy0Mm9v1x62MX01LShpsh2EIFqnPGN2yI5szHNb8629R/tPBbEPnbP+nWy/AB/HfSgBo0UXKg7kfL/AiUEg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      typescript: '>=5.0.0'
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
@@ -3349,6 +3467,9 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -4324,6 +4445,9 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
 
@@ -5135,6 +5259,9 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
@@ -5289,6 +5416,15 @@ packages:
 
   reselect@5.2.0:
     resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
+
+  resend@6.12.4:
+    resolution: {integrity: sha512-lRpJ2Hxd+ht+JPDm97juRcUp9HOMuZyxaRFRFmc9Tx8iNWiei94Dx9v6SWufgKk2667C/uCeKKspMotOHSpCSg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
 
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
@@ -5457,6 +5593,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -6386,6 +6525,24 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.3
       prettier: 2.8.8
+
+  '@commet/better-auth@7.0.0(@commet/node@7.3.0(typescript@5.9.3))(better-auth@1.6.16(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.2)(postgres@3.4.9))(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8))(better-call@1.3.6(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@commet/node': 7.3.0(typescript@5.9.3)
+      better-auth: 1.6.16(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.2)(postgres@3.4.9))(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8)
+      better-call: 1.3.6(zod@4.4.3)
+      zod: 4.4.3
+
+  '@commet/next@1.0.11(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)':
+    dependencies:
+      '@commet/node': 7.3.0(typescript@5.9.3)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    transitivePeerDependencies:
+      - typescript
+
+  '@commet/node@7.3.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
 
   '@date-fns/tz@1.4.1':
     optional: true
@@ -8079,6 +8236,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
@@ -8972,6 +9131,8 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-sha256@1.3.0: {}
+
   fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
@@ -9694,6 +9855,8 @@ snapshots:
       mlly: 1.8.0
       pathe: 2.0.3
 
+  postal-mime@2.7.4: {}
+
   postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
@@ -9884,6 +10047,11 @@ snapshots:
   require-from-string@2.0.2: {}
 
   reselect@5.2.0: {}
+
+  resend@6.12.4:
+    dependencies:
+      postal-mime: 2.7.4
+      standardwebhooks: 1.0.0
 
   resolve-alpn@1.2.1: {}
 
@@ -10166,6 +10334,11 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   statuses@2.0.2: {}
 


### PR DESCRIPTION
## Summary

- Adds a dedicated webhooks SaaS example under examples/webhooks.
- Uses published Commet packages instead of workspace package references.
- Demonstrates pricing, checkout, webhook verification, local billing state sync, and event history.

## Test Plan

- pnpm biome check --write examples/webhooks
- pnpm --filter webhooks-example typecheck
- POSTGRES_URL=postgres://user:pass@localhost:5432/webhooks BETTER_AUTH_SECRET=12345678901234567890123456789012 BETTER_AUTH_URL=http://localhost:3008 COMMET_API_KEY=ck_test_dummy COMMET_WEBHOOK_SECRET=whsec_dummy NEXT_PUBLIC_APP_URL=http://localhost:3008 pnpm --filter webhooks-example build
- pnpm biome check --write
- pnpm build
- pnpm typecheck
- git diff --check

## Notes

This PR intentionally excludes the @commet/next package fix, which is split into #169.