### PR TITLE
fix(examples): expose webhook envs to turbo builds

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -7,9 +7,12 @@
       "env": [
         "BETTER_AUTH_URL",
         "BETTER_AUTH_SECRET",
+        "COMMET_WEBHOOK_SECRET",
         "POSTGRES_URL",
         "COMMET_API_KEY",
-        "COMMET_ENVIRONMENT"
+        "COMMET_ENVIRONMENT",
+        "NEXT_PUBLIC_APP_URL",
+        "NEXT_PUBLIC_BETTER_AUTH_URL"
       ]
     },
     "dev": {


### PR DESCRIPTION
## Summary

- expose the webhooks example env vars to Turbo builds
- fixes Vercel deploys where env vars exist in Vercel but are filtered out by Turbo

## Test Plan

- pnpm biome check --write turbo.json
- pnpm --filter webhooks-example build
