### PR TITLE
fix(examples): acknowledge failed webhook processing

### DIFF
--- a/examples/webhooks/app/api/webhooks/commet/route.ts
+++ b/examples/webhooks/app/api/webhooks/commet/route.ts
@@ -97,8 +97,8 @@ export async function POST(request: NextRequest) {
     await markWebhookEventFailed(eventId);
     console.error("[commet-webhook] handler failed", { error, payload });
     return NextResponse.json(
-      { received: false, error: "Handler failed" },
-      { status: 500 },
+      { received: true, processed: false, error: "Handler failed" },
+      { status: 200 },
     );
   }
 


### PR DESCRIPTION
## Summary

- Return 200 when the webhooks example receives a valid Commet webhook but local processing fails
- Keep marking the local webhook event as failed so the example dashboard can surface the processing failure
- Avoid repeated Commet delivery retries for orphaned/stale test customers

## Test Plan

- pnpm --filter webhooks-example typecheck