### PR TITLE
fix(examples): build workspace deps in Vercel via turbo

### DIFF
--- a/examples/balance-ai/vercel.json
+++ b/examples/balance-ai/vercel.json
@@ -4,5 +4,6 @@
     "deploymentEnabled": {
       "dependabot/**": false
     }
-  }
+  },
+  "buildCommand": "pnpm db:push && cd ../.. && pnpm exec turbo build --filter=balance-ai-example"
 }

--- a/examples/balance-fixed/vercel.json
+++ b/examples/balance-fixed/vercel.json
@@ -4,5 +4,6 @@
     "deploymentEnabled": {
       "dependabot/**": false
     }
-  }
+  },
+  "buildCommand": "pnpm db:push && cd ../.. && pnpm exec turbo build --filter=balance-fixed-example"
 }

--- a/examples/credits/vercel.json
+++ b/examples/credits/vercel.json
@@ -4,5 +4,6 @@
     "deploymentEnabled": {
       "dependabot/**": false
     }
-  }
+  },
+  "buildCommand": "pnpm db:push && cd ../.. && pnpm exec turbo build --filter=credits-example"
 }

--- a/examples/fixed/vercel.json
+++ b/examples/fixed/vercel.json
@@ -4,5 +4,6 @@
     "deploymentEnabled": {
       "dependabot/**": false
     }
-  }
+  },
+  "buildCommand": "pnpm db:push && cd ../.. && pnpm exec turbo build --filter=fixed-example"
 }

--- a/examples/metered/vercel.json
+++ b/examples/metered/vercel.json
@@ -4,5 +4,6 @@
     "deploymentEnabled": {
       "dependabot/**": false
     }
-  }
+  },
+  "buildCommand": "pnpm db:push && cd ../.. && pnpm exec turbo build --filter=metered-example"
 }

--- a/examples/quota/vercel.json
+++ b/examples/quota/vercel.json
@@ -4,5 +4,6 @@
     "deploymentEnabled": {
       "dependabot/**": false
     }
-  }
+  },
+  "buildCommand": "pnpm db:push && cd ../.. && pnpm exec turbo build --filter=quota-example"
 }

--- a/examples/seats/vercel.json
+++ b/examples/seats/vercel.json
@@ -4,5 +4,6 @@
     "deploymentEnabled": {
       "dependabot/**": false
     }
-  }
+  },
+  "buildCommand": "pnpm db:push && cd ../.. && pnpm exec turbo build --filter=seats-example"
 }

--- a/examples/webhooks/vercel.json
+++ b/examples/webhooks/vercel.json
@@ -4,5 +4,6 @@
     "deploymentEnabled": {
       "dependabot/**": false
     }
-  }
+  },
+  "buildCommand": "pnpm db:push && cd ../.. && pnpm exec turbo build --filter=webhooks-example"
 }


### PR DESCRIPTION
## Problem

Every example's Vercel build runs `next build` (via `pnpm db:push && pnpm build`) **without building the workspace packages it imports**. `@commet/node`, `@commet/next` and `@commet/better-auth` all resolve from `dist/`, which doesn't exist on a clean Vercel checkout — so Turbopack fails with:

```
Module not found: Can't resolve '@commet/node'   (and @commet/next, @commet/better-auth)
```

It only builds locally because the `dist/` folders are already present.

## Fix

Set a `buildCommand` in each example's `vercel.json` that builds through turbo:

```
pnpm db:push && cd ../.. && pnpm exec turbo build --filter=<example>
```

`turbo.json` already declares `build.dependsOn: ["^build"]`, so turbo builds `@commet/node → @commet/next / @commet/better-auth → <example>` in dependency order before `next build` runs. `db:push` is preserved.

Applied to all 8 examples (balance-ai, balance-fixed, credits, fixed, metered, quota, seats, webhooks).

## Verify

`pnpm exec turbo build --filter=<example>` builds the three `@commet/*` packages (each emits its `dist/`) before the example, resolving the missing modules.
