### PR TITLE
fix(examples): webhooks uses workspace:* for internal deps

### DIFF
--- a/examples/webhooks/package.json
+++ b/examples/webhooks/package.json
@@ -14,9 +14,9 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
-    "@commet/better-auth": "7.0.0",
-    "@commet/next": "1.1.0",
-    "@commet/node": "7.3.0",
+    "@commet/better-auth": "workspace:*",
+    "@commet/next": "workspace:*",
+    "@commet/node": "workspace:*",
     "@radix-ui/react-slot": "1.2.5",
     "@vercel/analytics": "^2.0.1",
     "better-auth": "1.6.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -688,14 +688,14 @@ importers:
         specifier: ^1.3.0
         version: 1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@commet/better-auth':
-        specifier: 7.0.0
-        version: 7.0.0(@commet/node@7.3.0(typescript@5.9.3))(better-auth@1.6.16(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.2)(postgres@3.4.9))(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8))(better-call@1.3.6(zod@4.4.3))(zod@4.4.3)
+        specifier: workspace:*
+        version: link:../../packages/better-auth
       '@commet/next':
-        specifier: 1.1.0
-        version: 1.1.0(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
+        specifier: workspace:*
+        version: link:../../packages/next
       '@commet/node':
-        specifier: 7.3.0
-        version: 7.3.0(typescript@5.9.3)
+        specifier: workspace:*
+        version: link:../../packages/node
       '@radix-ui/react-slot':
         specifier: 1.2.5
         version: 1.2.5(@types/react@19.2.17)(react@19.2.7)
@@ -1282,27 +1282,6 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
-
-  '@commet/better-auth@7.0.0':
-    resolution: {integrity: sha512-robsxoBv7JtOwFE4fyymB/FIKfJBIMUd7W7G3I3usLi+cwdjGNdT35tuLgPHIbt/1VXv/FIjKHIpv/OQ+EKKBA==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      '@commet/node': ^7.0.0
-      better-auth: '>=1.5.6'
-      better-call: '>=1.3.2'
-      zod: '>=3.24.2'
-
-  '@commet/next@1.1.0':
-    resolution: {integrity: sha512-wX0EZEWax2bMvnf5+dHaiweuQ3cTge8nPDERHzyYJ36PYlVjK3Pwc21V+IB29gHcg544O+iZIfpYorruqE78+w==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      next: '>=16.0.0'
-
-  '@commet/node@7.3.0':
-    resolution: {integrity: sha512-dhDwy0Mm9v1x62MX01LShpsh2EIFqnPGN2yI5szHNb8629R/tPBbEPnbP+nWy/AB/HfSgBo0UXKg7kfL/AiUEg==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      typescript: '>=5.0.0'
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
@@ -6525,24 +6504,6 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.3
       prettier: 2.8.8
-
-  '@commet/better-auth@7.0.0(@commet/node@7.3.0(typescript@5.9.3))(better-auth@1.6.16(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.2)(postgres@3.4.9))(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8))(better-call@1.3.6(zod@4.4.3))(zod@4.4.3)':
-    dependencies:
-      '@commet/node': 7.3.0(typescript@5.9.3)
-      better-auth: 1.6.16(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.2)(postgres@3.4.9))(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8)
-      better-call: 1.3.6(zod@4.4.3)
-      zod: 4.4.3
-
-  '@commet/next@1.1.0(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)':
-    dependencies:
-      '@commet/node': 7.3.0(typescript@5.9.3)
-      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-    transitivePeerDependencies:
-      - typescript
-
-  '@commet/node@7.3.0(typescript@5.9.3)':
-    dependencies:
-      typescript: 5.9.3
 
   '@date-fns/tz@1.4.1':
     optional: true


### PR DESCRIPTION
## Problem

`examples/webhooks/package.json` pinned the internal packages to **fixed versions** (`@commet/node: 7.3.0`, `@commet/next: 1.1.0`, `@commet/better-auth: 7.0.0`) instead of `workspace:*` like the other 7 examples.

When the changesets bot opens a "Version Packages" PR, it rewrites those fixed versions to the new one (`@commet/node@7.4.0`) — which isn't published to npm yet. `pnpm install` then tries to fetch it from the registry:

```
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @commet/node@7.4.0
This error happened while installing a direct dependency of examples/webhooks
```

Because `pnpm install` resolves the **whole workspace**, this fails the install for **every** example's Vercel deploy, not just webhooks. Reproduced locally on `changeset-release/main`.

## Fix

Point webhooks' internal deps at `workspace:*`, matching the other examples. pnpm links the local packages, the install never touches npm, and the changesets bot stops rewriting them.

Verified: `pnpm install` passes.
