### PR TITLE
fix(cli): plans subcommands sent planId and flat overage/intro-offer shapes

### DIFF
--- a/.changeset/cli-plans-registry-fixes.md
+++ b/.changeset/cli-plans-registry-fixes.md
@@ -1,0 +1,11 @@
+---
+"commet": patch
+---
+
+Fix CLI flags that produced requests the API rejected or ignored:
+
+- The plans subcommands (`add-feature`, `update-feature`, `remove-feature`, `add-price`, `update-price`, `delete-price`, `set-default-price`, `set-regional-prices`, `delete-regional-prices`) sent the plan identifier as `planId`, so requests went to `/plans/undefined/...`. The `--plan-id` flag now maps to the `id` param the SDK expects.
+- `--overage-enabled`/`--overage-unit-price` and the `--intro-offer-*` flags sent flat keys the API strips. They now build the nested `overage` and `introOffer` objects.
+- Removed `--domain`, `--website`, `--language`, and `--industry` from `customers create`/`update` — the API does not accept these fields.
+- `features create --type` help now lists the `quota` type.
+- The `commet listen` example now uses a real event (`invoice.created`), and the agent help advertises the single MCP endpoint — the organization behind your credentials determines sandbox vs live mode.

--- a/packages/cli/src/commands/listen.ts
+++ b/packages/cli/src/commands/listen.ts
@@ -100,7 +100,7 @@ export const listenCommand = new Command("listen")
 Examples:
   $ commet listen 3000                          Forward to http://localhost:3000/
   $ commet listen localhost:3000/webhooks        Forward to a specific path
-  $ commet listen 3000 --events invoice.paid     Only forward invoice.paid events
+  $ commet listen 3000 --events invoice.created  Only forward invoice.created events
 `,
   )
   .action(async (url: string, options: ListenOptions) => {

--- a/packages/cli/src/commands/resources/factory.ts
+++ b/packages/cli/src/commands/resources/factory.ts
@@ -10,7 +10,42 @@ export interface ParamDef {
   description: string;
   required?: boolean;
   parse?: (value: string) => unknown;
+  /** Dot-separated path in the SDK params object, e.g. "overage.enabled". */
   sdkKey: string;
+}
+
+function commanderOptionKey(flag: string): string {
+  const longFlagMatch = flag.match(/--([a-z0-9-]+)/i);
+  if (!longFlagMatch?.[1]) {
+    throw new Error(`Cannot derive option name from flag: ${flag}`);
+  }
+  return longFlagMatch[1].replace(/-([a-z])/g, (_hyphen, letter: string) =>
+    letter.toUpperCase(),
+  );
+}
+
+function assignSdkKeyPath(
+  target: Record<string, unknown>,
+  sdkKey: string,
+  value: unknown,
+): void {
+  const segments = sdkKey.split(".");
+  const leafKey = segments.pop();
+  if (!leafKey) {
+    throw new Error(`Invalid sdkKey: ${sdkKey}`);
+  }
+  let current = target;
+  for (const segment of segments) {
+    const existing = current[segment];
+    if (typeof existing === "object" && existing !== null) {
+      current = existing as Record<string, unknown>;
+    } else {
+      const nested: Record<string, unknown> = {};
+      current[segment] = nested;
+      current = nested;
+    }
+  }
+  current[leafKey] = value;
 }
 
 export interface ActionDef {
@@ -66,13 +101,15 @@ export function createResourceCommand(def: ResourceDef): Command {
         } else {
           const built: Record<string, unknown> = {};
           for (const paramDef of actionDef.params) {
-            const rawValue = options[paramDef.sdkKey];
+            const rawValue = options[commanderOptionKey(paramDef.flag)];
             if (rawValue === undefined) {
               continue;
             }
-            built[paramDef.sdkKey] = paramDef.parse
-              ? paramDef.parse(rawValue)
-              : rawValue;
+            assignSdkKeyPath(
+              built,
+              paramDef.sdkKey,
+              paramDef.parse ? paramDef.parse(rawValue) : rawValue,
+            );
           }
           params = built;
         }

--- a/packages/cli/src/commands/resources/registry.ts
+++ b/packages/cli/src/commands/resources/registry.ts
@@ -22,26 +22,10 @@ const customersResource: ResourceDef = {
           description: "Full name",
           sdkKey: "fullName",
         },
-        { flag: "--domain <domain>", description: "Domain", sdkKey: "domain" },
-        {
-          flag: "--website <url>",
-          description: "Website URL",
-          sdkKey: "website",
-        },
         {
           flag: "--timezone <tz>",
           description: "Timezone",
           sdkKey: "timezone",
-        },
-        {
-          flag: "--language <lang>",
-          description: "Language code",
-          sdkKey: "language",
-        },
-        {
-          flag: "--industry <industry>",
-          description: "Industry",
-          sdkKey: "industry",
         },
         {
           flag: "--metadata <json>",
@@ -103,26 +87,10 @@ const customersResource: ResourceDef = {
           description: "Full name",
           sdkKey: "fullName",
         },
-        { flag: "--domain <domain>", description: "Domain", sdkKey: "domain" },
-        {
-          flag: "--website <url>",
-          description: "Website URL",
-          sdkKey: "website",
-        },
         {
           flag: "--timezone <tz>",
           description: "Timezone",
           sdkKey: "timezone",
-        },
-        {
-          flag: "--language <lang>",
-          description: "Language code",
-          sdkKey: "language",
-        },
-        {
-          flag: "--industry <industry>",
-          description: "Industry",
-          sdkKey: "industry",
         },
         {
           flag: "--metadata <json>",
@@ -686,7 +654,7 @@ const plansResource: ResourceDef = {
           flag: "--plan-id <id>",
           description: "Plan ID",
           required: true,
-          sdkKey: "planId",
+          sdkKey: "id",
         },
         {
           flag: "--feature-id <id>",
@@ -716,13 +684,13 @@ const plansResource: ResourceDef = {
           flag: "--overage-enabled <bool>",
           description: "Whether overage is enabled",
           parse: parseBool,
-          sdkKey: "overageEnabled",
+          sdkKey: "overage.enabled",
         },
         {
           flag: "--overage-unit-price <n>",
           description: "Overage unit price (fixed pricing)",
           parse: parseNumber,
-          sdkKey: "overageUnitPrice",
+          sdkKey: "overage.unitPrice",
         },
         {
           flag: "--pricing-mode <mode>",
@@ -751,7 +719,7 @@ const plansResource: ResourceDef = {
           flag: "--plan-id <id>",
           description: "Plan ID",
           required: true,
-          sdkKey: "planId",
+          sdkKey: "id",
         },
         {
           flag: "--feature-id <id>",
@@ -781,13 +749,13 @@ const plansResource: ResourceDef = {
           flag: "--overage-enabled <bool>",
           description: "Whether overage is enabled",
           parse: parseBool,
-          sdkKey: "overageEnabled",
+          sdkKey: "overage.enabled",
         },
         {
           flag: "--overage-unit-price <n>",
           description: "Overage unit price (fixed pricing)",
           parse: parseNumber,
-          sdkKey: "overageUnitPrice",
+          sdkKey: "overage.unitPrice",
         },
         {
           flag: "--pricing-mode <mode>",
@@ -816,7 +784,7 @@ const plansResource: ResourceDef = {
           flag: "--plan-id <id>",
           description: "Plan ID",
           required: true,
-          sdkKey: "planId",
+          sdkKey: "id",
         },
         {
           flag: "--feature-id <id>",
@@ -834,7 +802,7 @@ const plansResource: ResourceDef = {
           flag: "--plan-id <id>",
           description: "Plan ID",
           required: true,
-          sdkKey: "planId",
+          sdkKey: "id",
         },
         {
           flag: "--billing-interval <interval>",
@@ -878,24 +846,24 @@ const plansResource: ResourceDef = {
           flag: "--intro-offer-enabled <bool>",
           description: "Enable intro offer",
           parse: parseBool,
-          sdkKey: "introOfferEnabled",
+          sdkKey: "introOffer.enabled",
         },
         {
           flag: "--intro-offer-discount-type <type>",
           description: "Intro offer discount type: percentage or amount",
-          sdkKey: "introOfferDiscountType",
+          sdkKey: "introOffer.discountType",
         },
         {
           flag: "--intro-offer-discount-value <n>",
           description: "Intro offer discount value",
           parse: parseNumber,
-          sdkKey: "introOfferDiscountValue",
+          sdkKey: "introOffer.discountValue",
         },
         {
           flag: "--intro-offer-duration-cycles <n>",
           description: "Intro offer duration in cycles",
           parse: parseNumber,
-          sdkKey: "introOfferDurationCycles",
+          sdkKey: "introOffer.durationCycles",
         },
       ],
     },
@@ -907,7 +875,7 @@ const plansResource: ResourceDef = {
           flag: "--plan-id <id>",
           description: "Plan ID",
           required: true,
-          sdkKey: "planId",
+          sdkKey: "id",
         },
         {
           flag: "--price-id <id>",
@@ -949,24 +917,24 @@ const plansResource: ResourceDef = {
           flag: "--intro-offer-enabled <bool>",
           description: "Enable intro offer",
           parse: parseBool,
-          sdkKey: "introOfferEnabled",
+          sdkKey: "introOffer.enabled",
         },
         {
           flag: "--intro-offer-discount-type <type>",
           description: "Intro offer discount type: percentage or amount",
-          sdkKey: "introOfferDiscountType",
+          sdkKey: "introOffer.discountType",
         },
         {
           flag: "--intro-offer-discount-value <n>",
           description: "Intro offer discount value",
           parse: parseNumber,
-          sdkKey: "introOfferDiscountValue",
+          sdkKey: "introOffer.discountValue",
         },
         {
           flag: "--intro-offer-duration-cycles <n>",
           description: "Intro offer duration in cycles",
           parse: parseNumber,
-          sdkKey: "introOfferDurationCycles",
+          sdkKey: "introOffer.durationCycles",
         },
       ],
     },
@@ -978,7 +946,7 @@ const plansResource: ResourceDef = {
           flag: "--plan-id <id>",
           description: "Plan ID",
           required: true,
-          sdkKey: "planId",
+          sdkKey: "id",
         },
         {
           flag: "--price-id <id>",
@@ -996,7 +964,7 @@ const plansResource: ResourceDef = {
           flag: "--plan-id <id>",
           description: "Plan ID",
           required: true,
-          sdkKey: "planId",
+          sdkKey: "id",
         },
         {
           flag: "--price-id <id>",
@@ -1014,7 +982,7 @@ const plansResource: ResourceDef = {
           flag: "--plan-id <id>",
           description: "Plan ID",
           required: true,
-          sdkKey: "planId",
+          sdkKey: "id",
         },
         {
           flag: "--price-id <id>",
@@ -1040,7 +1008,7 @@ const plansResource: ResourceDef = {
           flag: "--plan-id <id>",
           description: "Plan ID",
           required: true,
-          sdkKey: "planId",
+          sdkKey: "id",
         },
         {
           flag: "--price-id <id>",
@@ -1093,7 +1061,7 @@ const featuresResource: ResourceDef = {
         },
         {
           flag: "--type <type>",
-          description: "Feature type: boolean, usage, or seats",
+          description: "Feature type: boolean, usage, seats, or quota",
           required: true,
           sdkKey: "type",
         },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -157,8 +157,7 @@ function printAgentInfo() {
     },
     mcp: {
       url: "https://commet.co/mcp",
-      sandbox: "https://sandbox.commet.co/mcp",
-      hint: "For full billing CRUD (plans, features, customers, subscriptions), connect to the MCP server.",
+      hint: "For full billing CRUD (plans, features, customers, subscriptions), connect to the MCP server. The organization behind your credentials determines sandbox vs live mode.",
     },
     auth: {
       interactive: "commet login",


### PR DESCRIPTION
Closes #188.

The plans subcommands sent the plan identifier as `planId` while the SDK expects `id`, so every request hit `/plans/undefined/...`. `--plan-id` now maps to `id`, and the registry supports dot-path sdk keys so the `--overage-*` and `--intro-offer-*` flags build the nested `overage` / `introOffer` objects the API expects (flat keys were silently stripped).

Also:
- Removed `customers create/update` flags the API ignores (`--domain`, `--website`, `--language`, `--industry`).
- `features create --type` help now lists `quota`.
- The `listen` example uses a real event (`invoice.created`).
- Agent help advertises the single MCP endpoint — the organization behind the credentials decides sandbox vs live.

Verified by intercepting the wire format: `plans add-feature` now sends `POST /api/v1/plans/{id}/features` with nested `overage`, `add-price` sends nested `introOffer`, and subscriptions/plan-groups keep their legitimate `planId` params.