### PR TITLE
feat: add per-subscription trial days

### DIFF
--- a/.changeset/calm-trials.md
+++ b/.changeset/calm-trials.md
@@ -1,0 +1,5 @@
+---
+"@commet/node": minor
+---
+
+Add per-subscription custom trial days to subscription creation.

--- a/packages/node/src/resources/subscriptions.ts
+++ b/packages/node/src/resources/subscriptions.ts
@@ -33,6 +33,7 @@ export interface CreateSubscriptionParams {
   billingInterval?: BillingInterval | null;
   initialSeats?: Record<string, number>;
   skipTrial?: boolean;
+  customTrialDays?: number;
   introOffer?: {
     discountType: DiscountType;
     discountValue: number;


### PR DESCRIPTION
## Summary
- add `customTrialDays?: number` to subscription creation
- add a minor changeset for `@commet/node`

## Validation
- lint
- build
- monorepo typecheck

Generated from the BIL-1726 OpenAPI contract.