### PR TITLE
feat: align CLI and SDK docs with API v8

### DIFF
--- a/.changeset/clean-cli-v8-usage.md
+++ b/.changeset/clean-cli-v8-usage.md
@@ -1,5 +1,10 @@
 ---
+"@commet/node": patch
 "commet": major
 ---
 
-Align the CLI with v8: use `featureCode` and `eventId` for usage, replace `feature-access can-use` with `usage check`, create Promo Codes from Promotional Offers, manage Offers and pricing Market Groups, select price variants, and make quota mutation retries honor `--idempotency-key`.
+Align the CLI with v8 by adding Offers, pricing Market Groups, selectable price variants, Offer-aware subscription flows, and the current customer and subscription fields.
+
+This release replaces `usage track --feature` with `--feature-code`, replaces its inline idempotency key with `--event-id`, replaces `feature-access can-use` with `usage check`, makes Promo Codes reference Promotional Offers, and sends quota idempotency keys as HTTP request options.
+
+Document Offers, pricing Markets, selectable price variants, and the current plan-change behavior in the Node SDK.

--- a/.changeset/clean-cli-v8-usage.md
+++ b/.changeset/clean-cli-v8-usage.md
@@ -1,0 +1,5 @@
+---
+"commet": major
+---
+
+Align the CLI with v8: use `featureCode` and `eventId` for usage, replace `feature-access can-use` with `usage check`, create Promo Codes from Promotional Offers, manage Offers and pricing Market Groups, select price variants, and send quota idempotency keys through the HTTP request option.

--- a/.changeset/clean-cli-v8-usage.md
+++ b/.changeset/clean-cli-v8-usage.md
@@ -2,4 +2,4 @@
 "commet": major
 ---
 
-Align the CLI with v8: use `featureCode` and `eventId` for usage, replace `feature-access can-use` with `usage check`, create Promo Codes from Promotional Offers, manage Offers and pricing Market Groups, select price variants, and send quota idempotency keys through the HTTP request option.
+Align the CLI with v8: use `featureCode` and `eventId` for usage, replace `feature-access can-use` with `usage check`, create Promo Codes from Promotional Offers, manage Offers and pricing Market Groups, select price variants, and make quota mutation retries honor `--idempotency-key`.

--- a/packages/better-auth/README.md
+++ b/packages/better-auth/README.md
@@ -147,9 +147,9 @@ portal({
 subscriptions({
   // Optional: Plan mappings for slug-based plan changes
   plans: [
-    { planId: "plan_123", slug: "starter" },
-    { planId: "plan_456", slug: "pro" },
-    { planId: "plan_789", slug: "enterprise" }
+    { planId: "pln_123", slug: "starter" },
+    { planId: "pln_456", slug: "pro" },
+    { planId: "pln_789", slug: "enterprise" }
   ]
 })
 ```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,6 +15,7 @@
     "dev": "tsup --watch",
     "lint": "biome lint src/",
     "lint:fix": "biome lint --write src/",
+    "validate:registry": "tsx scripts/validate-resource-registry.ts",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf .turbo node_modules dist"
   },
@@ -40,6 +41,7 @@
   },
   "devDependencies": {
     "@types/node": "24.13.1",
+    "tsx": "4.22.0",
     "tsup": "8.5.1",
     "typescript": "5.9.3"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,7 @@
     "lint": "biome lint src/",
     "lint:fix": "biome lint --write src/",
     "validate:registry": "tsx scripts/validate-resource-registry.ts",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && pnpm validate:registry",
     "clean": "rm -rf .turbo node_modules dist"
   },
   "keywords": [

--- a/packages/cli/scripts/validate-resource-registry.ts
+++ b/packages/cli/scripts/validate-resource-registry.ts
@@ -37,15 +37,66 @@ if (!commetClass) {
 const commetType = checker.getTypeAtLocation(commetClass);
 const failures: string[] = [];
 
-function parameterKeys(parameterType: ts.Type): Set<string> {
-  const variants = parameterType.isUnion()
-    ? parameterType.types
-    : [parameterType];
-  return new Set(
-    variants.flatMap((variant) =>
-      checker.getPropertiesOfType(variant).map((property) => property.name),
-    ),
+function typeVariants(type: ts.Type): ts.Type[] {
+  const nonNullableType = checker.getNonNullableType(type);
+  return nonNullableType.isUnion()
+    ? nonNullableType.types.flatMap(typeVariants)
+    : [nonNullableType];
+}
+
+function hasParameterPath(type: ts.Type, pathSegments: string[]): boolean {
+  const [segment, ...remainingSegments] = pathSegments;
+  if (!segment) return true;
+
+  return typeVariants(type).some((variant) => {
+    const property = checker.getPropertyOfType(variant, segment);
+    const propertyDeclaration =
+      property?.valueDeclaration ?? property?.declarations?.[0];
+    if (!(property && propertyDeclaration)) return false;
+    if (remainingSegments.length === 0) return true;
+
+    return hasParameterPath(
+      checker.getTypeOfSymbolAtLocation(property, propertyDeclaration),
+      remainingSegments,
+    );
+  });
+}
+
+function validateParameters(
+  resourceName: string,
+  actionName: string,
+  parameters: Array<{ sdkKey: string }>,
+  methodParameter: ts.Symbol | undefined,
+  parameterKind: string,
+): void {
+  if (parameters.length === 0) return;
+  if (!methodParameter) {
+    failures.push(
+      `${resourceName} ${actionName}: SDK method accepts no ${parameterKind}`,
+    );
+    return;
+  }
+
+  const methodParameterDeclaration =
+    methodParameter.valueDeclaration ?? methodParameter.declarations?.[0];
+  if (!methodParameterDeclaration) {
+    failures.push(
+      `${resourceName} ${actionName}: could not inspect SDK ${parameterKind}`,
+    );
+    return;
+  }
+
+  const methodParameterType = checker.getTypeOfSymbolAtLocation(
+    methodParameter,
+    methodParameterDeclaration,
   );
+  for (const parameter of parameters) {
+    if (!hasParameterPath(methodParameterType, parameter.sdkKey.split("."))) {
+      failures.push(
+        `${resourceName} ${actionName}: ${parameter.sdkKey} is not an SDK ${parameterKind}`,
+      );
+    }
+  }
 }
 
 for (const resourceDefinition of resourceDefinitions) {
@@ -96,41 +147,24 @@ for (const resourceDefinition of resourceDefinitions) {
     const bodyParameters = actionDefinition.params.filter(
       (parameter) => !parameter.requestOption,
     );
-    const firstParameter = signature?.getParameters()[0];
-
-    if (!firstParameter) {
-      if (bodyParameters.length > 0) {
-        failures.push(
-          `${resourceDefinition.name} ${actionName}: SDK method accepts no parameters`,
-        );
-      }
-      continue;
-    }
-
-    const firstParameterDeclaration =
-      firstParameter.valueDeclaration ?? firstParameter.declarations?.[0];
-    if (!firstParameterDeclaration) {
-      failures.push(
-        `${resourceDefinition.name} ${actionName}: could not inspect SDK parameters`,
-      );
-      continue;
-    }
-
-    const allowedKeys = parameterKeys(
-      checker.getTypeOfSymbolAtLocation(
-        firstParameter,
-        firstParameterDeclaration,
-      ),
+    const requestOptionParameters = actionDefinition.params.filter(
+      (parameter) => parameter.requestOption,
     );
-
-    for (const parameter of bodyParameters) {
-      const rootKey = parameter.sdkKey.split(".")[0];
-      if (rootKey && !allowedKeys.has(rootKey)) {
-        failures.push(
-          `${resourceDefinition.name} ${actionName}: ${parameter.sdkKey} is not an SDK parameter`,
-        );
-      }
-    }
+    const methodParameters = signature?.getParameters() ?? [];
+    validateParameters(
+      resourceDefinition.name,
+      actionName,
+      bodyParameters,
+      methodParameters[0],
+      "request parameter",
+    );
+    validateParameters(
+      resourceDefinition.name,
+      actionName,
+      requestOptionParameters,
+      methodParameters[bodyParameters.length > 0 ? 1 : 0],
+      "request option",
+    );
   }
 }
 

--- a/packages/cli/scripts/validate-resource-registry.ts
+++ b/packages/cli/scripts/validate-resource-registry.ts
@@ -1,0 +1,143 @@
+import path from "node:path";
+import ts from "typescript";
+import { resourceDefinitions } from "../src/commands/resources/registry";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "../../..");
+const nodePackageRoot = path.join(repositoryRoot, "packages/node");
+const nodeConfigPath = path.join(nodePackageRoot, "tsconfig.json");
+const configFile = ts.readConfigFile(nodeConfigPath, ts.sys.readFile);
+
+if (configFile.error) {
+  throw new Error(
+    ts.flattenDiagnosticMessageText(configFile.error.messageText, "\n"),
+  );
+}
+
+const parsedConfig = ts.parseJsonConfigFileContent(
+  configFile.config,
+  ts.sys,
+  nodePackageRoot,
+);
+const clientPath = path.join(nodePackageRoot, "src/client.ts");
+const program = ts.createProgram({
+  rootNames: [clientPath],
+  options: parsedConfig.options,
+});
+const checker = program.getTypeChecker();
+const clientSource = program.getSourceFile(clientPath);
+const commetClass = clientSource?.statements.find(
+  (statement): statement is ts.ClassDeclaration =>
+    ts.isClassDeclaration(statement) && statement.name?.text === "Commet",
+);
+
+if (!commetClass) {
+  throw new Error("Could not find the Commet client class");
+}
+
+const commetType = checker.getTypeAtLocation(commetClass);
+const failures: string[] = [];
+
+function parameterKeys(parameterType: ts.Type): Set<string> {
+  const variants = parameterType.isUnion()
+    ? parameterType.types
+    : [parameterType];
+  return new Set(
+    variants.flatMap((variant) =>
+      checker.getPropertiesOfType(variant).map((property) => property.name),
+    ),
+  );
+}
+
+for (const resourceDefinition of resourceDefinitions) {
+  const resourceSymbol = checker.getPropertyOfType(
+    commetType,
+    resourceDefinition.sdkProperty,
+  );
+  const resourceDeclaration =
+    resourceSymbol?.valueDeclaration ?? resourceSymbol?.declarations?.[0];
+
+  if (!(resourceSymbol && resourceDeclaration)) {
+    failures.push(
+      `${resourceDefinition.name}: SDK resource ${resourceDefinition.sdkProperty} does not exist`,
+    );
+    continue;
+  }
+
+  const resourceType = checker.getTypeOfSymbolAtLocation(
+    resourceSymbol,
+    resourceDeclaration,
+  );
+
+  for (const [actionName, actionDefinition] of Object.entries(
+    resourceDefinition.actions,
+  )) {
+    const methodSymbol = checker.getPropertyOfType(
+      resourceType,
+      actionDefinition.method,
+    );
+    const methodDeclaration =
+      methodSymbol?.valueDeclaration ?? methodSymbol?.declarations?.[0];
+
+    if (!(methodSymbol && methodDeclaration)) {
+      failures.push(
+        `${resourceDefinition.name} ${actionName}: SDK method ${actionDefinition.method} does not exist`,
+      );
+      continue;
+    }
+
+    const methodType = checker.getTypeOfSymbolAtLocation(
+      methodSymbol,
+      methodDeclaration,
+    );
+    const signature = checker.getSignaturesOfType(
+      methodType,
+      ts.SignatureKind.Call,
+    )[0];
+    const bodyParameters = actionDefinition.params.filter(
+      (parameter) => !parameter.requestOption,
+    );
+    const firstParameter = signature?.getParameters()[0];
+
+    if (!firstParameter) {
+      if (bodyParameters.length > 0) {
+        failures.push(
+          `${resourceDefinition.name} ${actionName}: SDK method accepts no parameters`,
+        );
+      }
+      continue;
+    }
+
+    const firstParameterDeclaration =
+      firstParameter.valueDeclaration ?? firstParameter.declarations?.[0];
+    if (!firstParameterDeclaration) {
+      failures.push(
+        `${resourceDefinition.name} ${actionName}: could not inspect SDK parameters`,
+      );
+      continue;
+    }
+
+    const allowedKeys = parameterKeys(
+      checker.getTypeOfSymbolAtLocation(
+        firstParameter,
+        firstParameterDeclaration,
+      ),
+    );
+
+    for (const parameter of bodyParameters) {
+      const rootKey = parameter.sdkKey.split(".")[0];
+      if (rootKey && !allowedKeys.has(rootKey)) {
+        failures.push(
+          `${resourceDefinition.name} ${actionName}: ${parameter.sdkKey} is not an SDK parameter`,
+        );
+      }
+    }
+  }
+}
+
+if (failures.length > 0) {
+  throw new Error(`CLI resource registry drift:\n${failures.join("\n")}`);
+}
+
+console.log(
+  `Validated ${resourceDefinitions.length} CLI resources against @commet/node`,
+);

--- a/packages/cli/src/commands/resources/factory.ts
+++ b/packages/cli/src/commands/resources/factory.ts
@@ -12,6 +12,7 @@ export interface ParamDef {
   parse?: (value: string) => unknown;
   /** Dot-separated path in the SDK params object, e.g. "overage.enabled". */
   sdkKey: string;
+  requestOption?: boolean;
 }
 
 function commanderOptionKey(flag: string): string {
@@ -92,10 +93,14 @@ export function createResourceCommand(def: ResourceDef): Command {
         const client = createSdkClient();
         const resource = client[
           def.sdkProperty as keyof typeof client
-        ] as unknown as Record<string, (params: unknown) => Promise<unknown>>;
+        ] as unknown as Record<
+          string,
+          (params: unknown, requestOptions?: unknown) => Promise<unknown>
+        >;
         const method = resource[actionDef.method];
 
         let params: unknown;
+        const requestOptions: Record<string, unknown> = {};
         if (actionDef.buildParams) {
           params = actionDef.buildParams(options);
         } else {
@@ -105,16 +110,23 @@ export function createResourceCommand(def: ResourceDef): Command {
             if (rawValue === undefined) {
               continue;
             }
-            assignSdkKeyPath(
-              built,
-              paramDef.sdkKey,
-              paramDef.parse ? paramDef.parse(rawValue) : rawValue,
-            );
+            const parsedValue = paramDef.parse
+              ? paramDef.parse(rawValue)
+              : rawValue;
+            if (paramDef.requestOption) {
+              assignSdkKeyPath(requestOptions, paramDef.sdkKey, parsedValue);
+              continue;
+            }
+            assignSdkKeyPath(built, paramDef.sdkKey, parsedValue);
           }
           params = built;
         }
 
-        const result = await method.call(resource, params);
+        const result = await method.call(
+          resource,
+          params,
+          Object.keys(requestOptions).length > 0 ? requestOptions : undefined,
+        );
 
         spinner?.succeed(`${def.name} ${actionName}`);
 
@@ -197,7 +209,10 @@ export function generateResourceSchema(
     for (const [actionName, actionDef] of Object.entries(def.actions)) {
       const params: Record<string, unknown> = {};
       for (const param of actionDef.params) {
-        params[param.sdkKey] = {
+        const schemaKey = param.requestOption
+          ? `requestOptions.${param.sdkKey}`
+          : param.sdkKey;
+        params[schemaKey] = {
           flag: param.flag,
           description: param.description,
           required: param.required ?? false,

--- a/packages/cli/src/commands/resources/factory.ts
+++ b/packages/cli/src/commands/resources/factory.ts
@@ -91,13 +91,19 @@ export function createResourceCommand(def: ResourceDef): Command {
 
       try {
         const client = createSdkClient();
-        const resource = client[
-          def.sdkProperty as keyof typeof client
-        ] as unknown as Record<
-          string,
-          (params: unknown, requestOptions?: unknown) => Promise<unknown>
-        >;
-        const method = resource[actionDef.method];
+        const resource = Reflect.get(client, def.sdkProperty);
+        if (
+          (typeof resource !== "object" || resource === null) &&
+          typeof resource !== "function"
+        ) {
+          throw new Error(`SDK resource ${def.sdkProperty} is unavailable`);
+        }
+        const method = Reflect.get(resource, actionDef.method);
+        if (typeof method !== "function") {
+          throw new Error(
+            `SDK method ${def.sdkProperty}.${actionDef.method} is unavailable`,
+          );
+        }
 
         let params: unknown;
         const requestOptions: Record<string, unknown> = {};

--- a/packages/cli/src/commands/resources/registry.ts
+++ b/packages/cli/src/commands/resources/registry.ts
@@ -18,9 +18,19 @@ const customersResource: ResourceDef = {
         },
         { flag: "--id <id>", description: "Custom customer ID", sdkKey: "id" },
         {
+          flag: "--external-id <id>",
+          description: "ID from your system",
+          sdkKey: "externalId",
+        },
+        {
           flag: "--full-name <name>",
           description: "Full name",
           sdkKey: "fullName",
+        },
+        {
+          flag: "--tax-document <value>",
+          description: "Tax document",
+          sdkKey: "taxDocument",
         },
         {
           flag: "--timezone <tz>",
@@ -39,6 +49,11 @@ const customersResource: ResourceDef = {
             "Address (JSON: {line1, city, postalCode, country, ...})",
           parse: parseJson,
           sdkKey: "address",
+        },
+        {
+          flag: "--address-id <id>",
+          description: "Existing customer address ID",
+          sdkKey: "addressId",
         },
       ],
     },
@@ -88,6 +103,16 @@ const customersResource: ResourceDef = {
           sdkKey: "fullName",
         },
         {
+          flag: "--external-id <id>",
+          description: "ID from your system",
+          sdkKey: "externalId",
+        },
+        {
+          flag: "--tax-document <value>",
+          description: "Tax document",
+          sdkKey: "taxDocument",
+        },
+        {
           flag: "--timezone <tz>",
           description: "Timezone",
           sdkKey: "timezone",
@@ -111,11 +136,6 @@ const customersResource: ResourceDef = {
       description: "List customers",
       params: [
         {
-          flag: "--search <query>",
-          description: "Search query",
-          sdkKey: "search",
-        },
-        {
           flag: "--limit <n>",
           description: "Max results",
           parse: parseNumber,
@@ -127,14 +147,9 @@ const customersResource: ResourceDef = {
           sdkKey: "cursor",
         },
         {
-          flag: "--start-date <date>",
-          description: "Start date filter",
-          sdkKey: "startDate",
-        },
-        {
-          flag: "--end-date <date>",
-          description: "End date filter",
-          sdkKey: "endDate",
+          flag: "--external-id <id>",
+          description: "Filter by external ID",
+          sdkKey: "externalId",
         },
       ],
     },
@@ -173,6 +188,11 @@ const subscriptionsResource: ResourceDef = {
           sdkKey: "billingInterval",
         },
         {
+          flag: "--price-id <id>",
+          description: "Selectable plan price ID",
+          sdkKey: "priceId",
+        },
+        {
           flag: "--initial-seats <json>",
           description: "Initial seats map (JSON: {featureCode: count})",
           parse: parseJson,
@@ -183,6 +203,27 @@ const subscriptionsResource: ResourceDef = {
           description: "Skip trial period",
           parse: parseBool,
           sdkKey: "skipTrial",
+        },
+        {
+          flag: "--custom-trial-days <n>",
+          description: "Override the catalog trial duration",
+          parse: parseNumber,
+          sdkKey: "customTrialDays",
+        },
+        {
+          flag: "--offer-id <id>",
+          description: "Explicit Introductory Offer ID",
+          sdkKey: "offerId",
+        },
+        {
+          flag: "--promo-code <code>",
+          description: "Promotional Offer promo code",
+          sdkKey: "promoCode",
+        },
+        {
+          flag: "--provider <provider>",
+          description: "Initial checkout provider override",
+          sdkKey: "provider",
         },
         {
           flag: "--name <name>",
@@ -208,9 +249,15 @@ const subscriptionsResource: ResourceDef = {
         if (options.planId) params.planId = options.planId;
         if (options.billingInterval)
           params.billingInterval = options.billingInterval;
+        if (options.priceId) params.priceId = options.priceId;
         if (options.initialSeats)
           params.initialSeats = parseJson(options.initialSeats);
         if (options.skipTrial) params.skipTrial = parseBool(options.skipTrial);
+        if (options.customTrialDays)
+          params.customTrialDays = parseNumber(options.customTrialDays);
+        if (options.offerId) params.offerId = options.offerId;
+        if (options.promoCode) params.promoCode = options.promoCode;
+        if (options.provider) params.provider = options.provider;
         if (options.name) params.name = options.name;
         if (options.startDate) params.startDate = options.startDate;
         if (options.successUrl) params.successUrl = options.successUrl;
@@ -343,17 +390,6 @@ const subscriptionsResource: ResourceDef = {
           flag: "--status <status>",
           description: "Filter by status",
           sdkKey: "status",
-        },
-        {
-          flag: "--limit <n>",
-          description: "Max results",
-          parse: parseNumber,
-          sdkKey: "limit",
-        },
-        {
-          flag: "--cursor <cursor>",
-          description: "Pagination cursor",
-          sdkKey: "cursor",
         },
       ],
     },
@@ -498,17 +534,6 @@ const plansResource: ResourceDef = {
           description: "Include private plans",
           parse: parseBool,
           sdkKey: "includePrivate",
-        },
-        {
-          flag: "--limit <n>",
-          description: "Max results",
-          parse: parseNumber,
-          sdkKey: "limit",
-        },
-        {
-          flag: "--cursor <cursor>",
-          description: "Pagination cursor",
-          sdkKey: "cursor",
         },
       ],
     },
@@ -758,17 +783,6 @@ const plansResource: ResourceDef = {
           sdkKey: "overage.unitPrice",
         },
         {
-          flag: "--pricing-mode <mode>",
-          description: "Pricing mode: fixed or ai_model",
-          sdkKey: "pricingMode",
-        },
-        {
-          flag: "--margin <n>",
-          description: "Margin percentage (ai_model pricing)",
-          parse: parseNumber,
-          sdkKey: "margin",
-        },
-        {
           flag: "--credits-per-unit <n>",
           description: "Credits per unit",
           parse: parseNumber,
@@ -814,9 +828,13 @@ const plansResource: ResourceDef = {
         {
           flag: "--price <n>",
           description: "Price in cents",
-          required: true,
           parse: parseNumber,
           sdkKey: "price",
+        },
+        {
+          flag: "--inherits-from-price-id <id>",
+          description: "Base price ID inherited by this selectable variant",
+          sdkKey: "inheritsFromPriceId",
         },
         {
           flag: "--trial-days <n>",
@@ -843,27 +861,16 @@ const plansResource: ResourceDef = {
           sdkKey: "includedCredits",
         },
         {
-          flag: "--intro-offer-enabled <bool>",
-          description: "Enable intro offer",
-          parse: parseBool,
-          sdkKey: "introOffer.enabled",
+          flag: "--market-prices <json>",
+          description: "Market prices (JSON array)",
+          parse: parseJson,
+          sdkKey: "marketPrices",
         },
         {
-          flag: "--intro-offer-discount-type <type>",
-          description: "Intro offer discount type: percentage or amount",
-          sdkKey: "introOffer.discountType",
-        },
-        {
-          flag: "--intro-offer-discount-value <n>",
-          description: "Intro offer discount value",
-          parse: parseNumber,
-          sdkKey: "introOffer.discountValue",
-        },
-        {
-          flag: "--intro-offer-duration-cycles <n>",
-          description: "Intro offer duration in cycles",
-          parse: parseNumber,
-          sdkKey: "introOffer.durationCycles",
+          flag: "--metadata <json>",
+          description: "Price metadata (JSON)",
+          parse: parseJson,
+          sdkKey: "metadata",
         },
       ],
     },
@@ -914,27 +921,16 @@ const plansResource: ResourceDef = {
           sdkKey: "includedCredits",
         },
         {
-          flag: "--intro-offer-enabled <bool>",
-          description: "Enable intro offer",
-          parse: parseBool,
-          sdkKey: "introOffer.enabled",
+          flag: "--market-prices <json>",
+          description: "Market prices (JSON array)",
+          parse: parseJson,
+          sdkKey: "marketPrices",
         },
         {
-          flag: "--intro-offer-discount-type <type>",
-          description: "Intro offer discount type: percentage or amount",
-          sdkKey: "introOffer.discountType",
-        },
-        {
-          flag: "--intro-offer-discount-value <n>",
-          description: "Intro offer discount value",
-          parse: parseNumber,
-          sdkKey: "introOffer.discountValue",
-        },
-        {
-          flag: "--intro-offer-duration-cycles <n>",
-          description: "Intro offer duration in cycles",
-          parse: parseNumber,
-          sdkKey: "introOffer.durationCycles",
+          flag: "--metadata <json>",
+          description: "Price metadata to merge (JSON)",
+          parse: parseJson,
+          sdkKey: "metadata",
         },
       ],
     },
@@ -1154,24 +1150,6 @@ const featureAccessResource: ResourceDef = {
         },
       ],
     },
-    "can-use": {
-      method: "canUse",
-      description: "Check if a customer can use one more unit of a feature",
-      params: [
-        {
-          flag: "--customer-id <id>",
-          description: "Customer ID",
-          required: true,
-          sdkKey: "customerId",
-        },
-        {
-          flag: "--code <code>",
-          description: "Feature code",
-          required: true,
-          sdkKey: "code",
-        },
-      ],
-    },
   },
 };
 
@@ -1315,10 +1293,10 @@ const usageResource: ResourceDef = {
       description: "Track a usage event",
       params: [
         {
-          flag: "--feature <code>",
+          flag: "--feature-code <code>",
           description: "Feature code",
           required: true,
-          sdkKey: "feature",
+          sdkKey: "featureCode",
         },
         {
           flag: "--customer-id <id>",
@@ -1362,9 +1340,9 @@ const usageResource: ResourceDef = {
           sdkKey: "cacheWriteTokens",
         },
         {
-          flag: "--idempotency-key <key>",
-          description: "Idempotency key for deduplication",
-          sdkKey: "idempotencyKey",
+          flag: "--event-id <id>",
+          description: "Caller-owned event ID for deduplication",
+          sdkKey: "eventId",
         },
         {
           flag: "--timestamp <ts>",
@@ -1380,11 +1358,10 @@ const usageResource: ResourceDef = {
       ],
       buildParams: (options: Record<string, string>) => {
         const params: Record<string, unknown> = {
-          feature: options.feature,
+          featureCode: options.featureCode,
           customerId: options.customerId,
         };
-        if (options.idempotencyKey)
-          params.idempotencyKey = options.idempotencyKey;
+        if (options.eventId) params.eventId = options.eventId;
         if (options.timestamp) params.timestamp = options.timestamp;
         if (options.properties)
           params.properties = parseJson(options.properties);
@@ -2149,23 +2126,15 @@ const promoCodesResource: ResourceDef = {
           sdkKey: "code",
         },
         {
-          flag: "--discount-type <type>",
-          description: "Discount type: percentage or amount",
+          flag: "--offer-id <id>",
+          description: "Promotional Offer ID",
           required: true,
-          sdkKey: "discountType",
+          sdkKey: "offerId",
         },
         {
-          flag: "--discount-value <n>",
-          description: "Discount value",
-          required: true,
-          parse: parseNumber,
-          sdkKey: "discountValue",
-        },
-        {
-          flag: "--duration-cycles <n>",
-          description: "Duration in billing cycles",
-          parse: parseNumber,
-          sdkKey: "durationCycles",
+          flag: "--billing-interval <interval>",
+          description: "Optional billing interval restriction",
+          sdkKey: "billingInterval",
         },
         {
           flag: "--max-redemptions <n>",
@@ -2197,6 +2166,11 @@ const promoCodesResource: ResourceDef = {
           sdkKey: "id",
         },
         {
+          flag: "--billing-interval <interval>",
+          description: "Optional billing interval restriction",
+          sdkKey: "billingInterval",
+        },
+        {
           flag: "--max-redemptions <n>",
           description: "Maximum number of redemptions",
           parse: parseNumber,
@@ -2218,6 +2192,278 @@ const promoCodesResource: ResourceDef = {
           description: "Restrict to plan IDs (JSON array)",
           parse: parseJson,
           sdkKey: "planIds",
+        },
+      ],
+    },
+  },
+};
+
+const offersResource: ResourceDef = {
+  name: "offers",
+  description: "Manage Introductory and Promotional Offers",
+  sdkProperty: "offers",
+  actions: {
+    list: {
+      method: "list",
+      description: "List offers",
+      params: [
+        {
+          flag: "--limit <n>",
+          description: "Max results",
+          parse: parseNumber,
+          sdkKey: "limit",
+        },
+        {
+          flag: "--cursor <cursor>",
+          description: "Pagination cursor",
+          sdkKey: "cursor",
+        },
+        {
+          flag: "--plan-price-id <id>",
+          description: "Filter by plan price ID",
+          sdkKey: "planPriceId",
+        },
+        {
+          flag: "--purpose <purpose>",
+          description: "Filter by introductory or promotional purpose",
+          sdkKey: "purpose",
+        },
+        {
+          flag: "--active <bool>",
+          description: "Filter by active status",
+          parse: parseBool,
+          sdkKey: "active",
+        },
+      ],
+    },
+    get: {
+      method: "get",
+      description: "Get an offer",
+      params: [
+        {
+          flag: "--id <id>",
+          description: "Offer ID",
+          required: true,
+          sdkKey: "id",
+        },
+      ],
+    },
+    create: {
+      method: "create",
+      description: "Create an offer",
+      params: [
+        {
+          flag: "--name <name>",
+          description: "Offer name",
+          required: true,
+          sdkKey: "name",
+        },
+        {
+          flag: "--purpose <purpose>",
+          description: "introductory or promotional",
+          required: true,
+          sdkKey: "purpose",
+        },
+        {
+          flag: "--plan-price-ids <json>",
+          description: "Plan price IDs (JSON array)",
+          required: true,
+          parse: parseJson,
+          sdkKey: "planPriceIds",
+        },
+        {
+          flag: "--phases <json>",
+          description: "Offer phases (JSON array)",
+          required: true,
+          parse: parseJson,
+          sdkKey: "phases",
+        },
+        {
+          flag: "--starts-at <date>",
+          description: "Start date (ISO 8601)",
+          sdkKey: "startsAt",
+        },
+        {
+          flag: "--ends-at <date>",
+          description: "End date (ISO 8601)",
+          sdkKey: "endsAt",
+        },
+        {
+          flag: "--active <bool>",
+          description: "Whether the offer is active",
+          parse: parseBool,
+          sdkKey: "active",
+        },
+        {
+          flag: "--metadata <json>",
+          description: "Metadata (JSON)",
+          parse: parseJson,
+          sdkKey: "metadata",
+        },
+      ],
+    },
+    update: {
+      method: "update",
+      description: "Replace an offer definition",
+      params: [
+        {
+          flag: "--id <id>",
+          description: "Offer ID",
+          required: true,
+          sdkKey: "id",
+        },
+        {
+          flag: "--name <name>",
+          description: "Offer name",
+          required: true,
+          sdkKey: "name",
+        },
+        {
+          flag: "--purpose <purpose>",
+          description: "introductory or promotional",
+          required: true,
+          sdkKey: "purpose",
+        },
+        {
+          flag: "--plan-price-ids <json>",
+          description: "Plan price IDs (JSON array)",
+          required: true,
+          parse: parseJson,
+          sdkKey: "planPriceIds",
+        },
+        {
+          flag: "--phases <json>",
+          description: "Offer phases (JSON array)",
+          required: true,
+          parse: parseJson,
+          sdkKey: "phases",
+        },
+        {
+          flag: "--starts-at <date>",
+          description: "Start date (ISO 8601)",
+          sdkKey: "startsAt",
+        },
+        {
+          flag: "--ends-at <date>",
+          description: "End date (ISO 8601)",
+          sdkKey: "endsAt",
+        },
+        {
+          flag: "--active <bool>",
+          description: "Whether the offer is active",
+          parse: parseBool,
+          sdkKey: "active",
+        },
+        {
+          flag: "--metadata <json>",
+          description: "Metadata (JSON)",
+          parse: parseJson,
+          sdkKey: "metadata",
+        },
+      ],
+    },
+    delete: {
+      method: "delete",
+      description: "Archive an offer",
+      params: [
+        {
+          flag: "--id <id>",
+          description: "Offer ID",
+          required: true,
+          sdkKey: "id",
+        },
+      ],
+    },
+  },
+};
+
+const pricingResource: ResourceDef = {
+  name: "pricing",
+  description: "Manage reusable pricing market groups",
+  sdkProperty: "pricing",
+  actions: {
+    "list-market-groups": {
+      method: "listMarketGroups",
+      description: "List market groups",
+      params: [],
+    },
+    "get-market-group": {
+      method: "getMarketGroup",
+      description: "Get a market group",
+      params: [
+        {
+          flag: "--id <id>",
+          description: "Market group ID",
+          required: true,
+          sdkKey: "id",
+        },
+      ],
+    },
+    "create-market-group": {
+      method: "createMarketGroup",
+      description: "Create a market group",
+      params: [
+        {
+          flag: "--name <name>",
+          description: "Market group name",
+          required: true,
+          sdkKey: "name",
+        },
+        {
+          flag: "--country-codes <json>",
+          description: "ISO country codes (JSON array)",
+          required: true,
+          parse: parseJson,
+          sdkKey: "countryCodes",
+        },
+        {
+          flag: "--metadata <json>",
+          description: "Metadata (JSON)",
+          parse: parseJson,
+          sdkKey: "metadata",
+        },
+      ],
+    },
+    "update-market-group": {
+      method: "updateMarketGroup",
+      description: "Replace a market group",
+      params: [
+        {
+          flag: "--id <id>",
+          description: "Market group ID",
+          required: true,
+          sdkKey: "id",
+        },
+        {
+          flag: "--name <name>",
+          description: "Market group name",
+          required: true,
+          sdkKey: "name",
+        },
+        {
+          flag: "--country-codes <json>",
+          description: "ISO country codes (JSON array)",
+          required: true,
+          parse: parseJson,
+          sdkKey: "countryCodes",
+        },
+        {
+          flag: "--metadata <json>",
+          description: "Metadata (JSON)",
+          parse: parseJson,
+          sdkKey: "metadata",
+        },
+      ],
+    },
+    "delete-market-group": {
+      method: "deleteMarketGroup",
+      description: "Delete an unused market group",
+      params: [
+        {
+          flag: "--id <id>",
+          description: "Market group ID",
+          required: true,
+          sdkKey: "id",
         },
       ],
     },
@@ -2697,8 +2943,9 @@ const quotaResource: ResourceDef = {
         },
         {
           flag: "--idempotency-key <key>",
-          description: "Idempotency key for deduplication",
+          description: "HTTP idempotency key for request deduplication",
           sdkKey: "idempotencyKey",
+          requestOption: true,
         },
       ],
     },
@@ -2731,8 +2978,9 @@ const quotaResource: ResourceDef = {
         },
         {
           flag: "--idempotency-key <key>",
-          description: "Idempotency key for deduplication",
+          description: "HTTP idempotency key for request deduplication",
           sdkKey: "idempotencyKey",
+          requestOption: true,
         },
       ],
     },
@@ -2764,8 +3012,9 @@ const quotaResource: ResourceDef = {
         },
         {
           flag: "--idempotency-key <key>",
-          description: "Idempotency key for deduplication",
+          description: "HTTP idempotency key for request deduplication",
           sdkKey: "idempotencyKey",
+          requestOption: true,
         },
       ],
     },
@@ -2817,7 +3066,9 @@ export const resourceDefinitions: ResourceDef[] = [
   apiKeysResource,
   invoicesResource,
   transactionsResource,
+  offersResource,
   promoCodesResource,
+  pricingResource,
   planGroupsResource,
   paymentsResource,
   payoutsResource,

--- a/packages/cli/src/commands/resources/registry.ts
+++ b/packages/cli/src/commands/resources/registry.ts
@@ -322,6 +322,11 @@ const subscriptionsResource: ResourceDef = {
           required: true,
           sdkKey: "id",
         },
+        {
+          flag: "--offer-id <id>",
+          description: "Promotional Offer ID for a canceled subscription",
+          sdkKey: "offerId",
+        },
       ],
     },
     "create-recovery-link": {
@@ -375,6 +380,16 @@ const subscriptionsResource: ResourceDef = {
           description: "New billing interval",
           sdkKey: "newBillingInterval",
         },
+        {
+          flag: "--offer-id <id>",
+          description: "Promotional Offer ID for an immediate change",
+          sdkKey: "offerId",
+        },
+        {
+          flag: "--success-url <url>",
+          description: "Redirect URL when the change requires checkout",
+          sdkKey: "successUrl",
+        },
       ],
     },
     list: {
@@ -406,12 +421,18 @@ const subscriptionsResource: ResourceDef = {
         {
           flag: "--plan-id <planId>",
           description: "New plan ID",
+          required: true,
           sdkKey: "planId",
         },
         {
           flag: "--billing-interval <interval>",
           description: "New billing interval",
           sdkKey: "billingInterval",
+        },
+        {
+          flag: "--offer-id <id>",
+          description: "Promotional Offer ID to include in the preview",
+          sdkKey: "offerId",
         },
       ],
     },
@@ -1351,7 +1372,8 @@ const usageResource: ResourceDef = {
         },
         {
           flag: "--properties <json>",
-          description: "Event properties (JSON: {key: value})",
+          description:
+            'Event properties (JSON array: [{"property":"region","value":"us"}])',
           parse: parseJson,
           sdkKey: "properties",
         },
@@ -1400,7 +1422,6 @@ const usageResource: ResourceDef = {
         {
           flag: "--quantity <n>",
           description: "Quantity to check",
-          required: true,
           parse: parseNumber,
           sdkKey: "quantity",
         },

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -97,6 +97,52 @@ const portal = await commet.portal.getUrl({
 });
 ```
 
+## Offers and selectable pricing
+
+Create reusable country Markets and attach market prices to a base price or an inherited selectable variant:
+
+```typescript
+const argentina = await commet.pricing.createMarketGroup({
+  name: 'Argentina',
+  countryCodes: ['AR'],
+});
+
+const variant = await commet.plans.addPrice({
+  id: 'pln_pro',
+  billingInterval: 'monthly',
+  inheritsFromPriceId: 'pp_monthly',
+  marketPrices: [{
+    marketGroupId: argentina.id,
+    currency: 'ars',
+    price: 1_500_000,
+  }],
+});
+
+await commet.subscriptions.create({
+  customerId: 'cus_123',
+  planId: 'pln_pro',
+  priceId: variant.id,
+});
+```
+
+Offers own discount phases. Promo Codes reference Promotional Offers instead of duplicating discount fields:
+
+```typescript
+const offer = await commet.offers.create({
+  name: 'First three months at 25% off',
+  purpose: 'promotional',
+  planPriceIds: ['pp_monthly'],
+  phases: [{ type: 'percentage', percentage: 2500, durationCycles: 3 }],
+});
+
+await commet.promoCodes.create({
+  code: 'LAUNCH25',
+  offerId: offer.id,
+});
+```
+
+Omitting `priceId` preserves default price resolution and still applies Currency Pricing and Markets. A subscription keeps the selected price identity and renews from that catalog price's current value.
+
 ## Type Safety
 
 Use the [Commet CLI](https://www.npmjs.com/package/commet) to generate TypeScript types from your organization:

--- a/packages/node/src/resources/subscriptions.ts
+++ b/packages/node/src/resources/subscriptions.ts
@@ -289,7 +289,7 @@ export class SubscriptionsResource {
     );
   }
 
-  /** Preview proration details for an immediate plan change (an upgrade or a longer interval) without applying it. Returns credit, charge, and net amount. The target plan must belong to the same plan group as the current plan, otherwise a 400 with code `plans_not_in_same_group` is returned. A change between two free plans has nothing to prorate and returns a zero-amount estimate. Downgrades — a cheaper plan in the same group, or a shorter interval — are scheduled for the end of the current period instead of being prorated, so they return a 400 with code `plan_change_scheduled`; apply those via the change-plan endpoint. Pass offerId to quote the destination plan with a Promotional Offer. */
+  /** Preview proration details for an immediate plan change (a higher-sort-order plan or a longer interval) without applying it. Returns credit, charge, and net amount. The target plan must belong to the same plan group as the current plan, otherwise a 400 with code `plans_not_in_same_group` is returned. A change between two free plans has nothing to prorate and returns a zero-amount estimate. Downgrades — a lower-sort-order plan in the same group, or a shorter interval — are scheduled for the end of the current period instead of being prorated, so they return a 400 with code `plan_change_scheduled`; apply those via the change-plan endpoint. Pass offerId to quote the destination plan with a Promotional Offer. */
   async previewChange(
     params: PreviewChangePlanParams,
     options?: RequestOptions,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -863,6 +863,9 @@ importers:
       tsup:
         specifier: 8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.0)(typescript@5.9.3)(yaml@2.8.3)
+      tsx:
+        specifier: 4.22.0
+        version: 4.22.0
       typescript:
         specifier: 5.9.3
         version: 5.9.3


### PR DESCRIPTION
## Summary

- align the CLI resource registry with the released Node SDK v8 surface
- add Offers, pricing Market Groups, selectable price variants, and current subscription Offer options
- move quota idempotency to HTTP request options and validate request body plus nested RequestOptions paths against `@commet/node`
- replace v7 usage flags and commands with `featureCode`, `eventId`, and `usage check`
- update Node and Better Auth documentation for current IDs, Offers, and Markets
- release the breaking CLI changes as `commet` 4.0.0 through a major Changeset

The `@commet/node` HTTP surface is unchanged; its source diff is generated JSDoc only.

## Verification

- `pnpm --filter @commet/node test` — 12 files and 123 tests passed
- `pnpm typecheck` — 6 tasks passed; all 22 CLI resources validated against `@commet/node`
- `pnpm build` — 5 tasks passed
- `pnpm biome check --write` — 543 files checked with no blocking diagnostics
- final code review — passed with no blockers

## Release

Changesets and CI own the CLI 4.0.0 version bump and npm publication.