### PR TITLE
fix: define safe CLI config contract

### DIFF
--- a/.changeset/tough-config-sync.md
+++ b/.changeset/tough-config-sync.md
@@ -1,0 +1,6 @@
+---
+"@commet/node": major
+"commet": major
+---
+
+Replace the ambiguous config price `amount` with versioned integer USD `amountInCents`, validate config and numeric CLI inputs at runtime, make push failures exit non-zero, and keep pull/diff/push on the same monetary scale.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       
       - name: Type check
         run: pnpm typecheck
+
+      - name: Unit tests
+        run: pnpm test:unit
       
       - name: Lint
         run: pnpm lint

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "turbo lint --filter=./packages/*",
     "lint:fix": "turbo lint:fix --filter=./packages/*",
     "typecheck": "turbo typecheck --filter=./packages/*",
+    "test:unit": "turbo test:unit --filter=./packages/*",
     "clean": "turbo clean && rm -rf node_modules .turbo",
     "format": "biome format --write .",
     "format:check": "biome format .",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -70,6 +70,35 @@ commet plans list      # List plans
 commet customers list  # List customers
 ```
 
+## Config as Code
+
+```typescript
+import { defineConfig } from "@commet/node";
+
+export default defineConfig({
+  schemaVersion: 1,
+  features: {
+    api_calls: { name: "API calls", type: "usage", unitName: "call" },
+  },
+  plans: {
+    pro: {
+      name: "Pro",
+      consumptionModel: "metered",
+      defaultInterval: "monthly",
+      prices: [{ interval: "monthly", amountInCents: 499 }],
+      features: {
+        api_calls: {
+          included: 1_000,
+          overage: { unitPrice: 10_000 },
+        },
+      },
+    },
+  },
+});
+```
+
+`amountInCents` is an integer USD amount (`499` = `$4.99`). Overage `unitPrice` uses rate scale (`10_000` = `$1.00` per unit). Run `commet pull --yes` to regenerate configs that still use the removed `amount` field.
+
 ## Documentation
 
 Visit [commet.co/docs](https://commet.co/docs) for:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -97,7 +97,9 @@ export default defineConfig({
 });
 ```
 
-`amountInCents` is an integer USD amount (`499` = `$4.99`). Overage `unitPrice` uses rate scale (`10_000` = `$1.00` per unit). Run `commet pull --yes` to regenerate configs that still use the removed `amount` field.
+`amountInCents` is an integer USD amount (`499` = `$4.99`). Overage `unitPrice` uses rate scale (`10_000` = `$1.00` per unit).
+
+To migrate an older config, commit or back up the file first, add `schemaVersion: 1`, then replace each `amount`. Rename generated integer values directly (`amount: 499` becomes `amountInCents: 499`); convert hand-written decimal USD values to exact cents (`amount: 4.99` becomes `amountInCents: 499`). Run `commet push --dry-run` before applying it.
 
 ## Documentation
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,6 +17,7 @@
     "lint:fix": "biome lint --write src/",
     "validate:registry": "tsx scripts/validate-resource-registry.ts",
     "typecheck": "tsc --noEmit && pnpm validate:registry",
+    "test:unit": "vitest run",
     "clean": "rm -rf .turbo node_modules dist"
   },
   "keywords": [
@@ -43,7 +44,8 @@
     "@types/node": "24.13.1",
     "tsx": "4.22.0",
     "tsup": "8.5.1",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "vitest": "4.1.8"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -1,11 +1,11 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { BillingConfig, Feature, FeatureDef } from "@commet/node";
 import { confirm } from "@inquirer/prompts";
 import chalk from "chalk";
 import { Command } from "commander";
 import ora from "ora";
 import { findConfigFile, loadBillingConfig } from "../utils/config-loader";
+import { remoteStateToBillingConfig } from "../utils/config-mapping";
 import { computeDiff, formatDiff, type RemoteState } from "../utils/diff";
 import { generateConfigFile } from "../utils/generator";
 import { isAgentMode, requireOrgContext } from "../utils/output";
@@ -15,30 +15,6 @@ interface PullOptions {
   yes?: boolean;
   dryRun?: boolean;
   output?: string;
-}
-
-function toFeatureDef(feature: Feature): FeatureDef {
-  if (feature.type === "boolean") {
-    return {
-      name: feature.name,
-      type: "boolean",
-      ...(feature.description ? { description: feature.description } : {}),
-    };
-  }
-  if (feature.type === "seats") {
-    return {
-      name: feature.name,
-      type: "seats",
-      ...(feature.unitName ? { unitName: feature.unitName } : {}),
-      ...(feature.description ? { description: feature.description } : {}),
-    };
-  }
-  return {
-    name: feature.name,
-    type: "usage",
-    ...(feature.unitName ? { unitName: feature.unitName } : {}),
-    ...(feature.description ? { description: feature.description } : {}),
-  };
 }
 
 export const pullCommand = new Command("pull")
@@ -182,56 +158,49 @@ Examples:
 
     const localConfig = localLoaded.config;
 
-    const remoteAsConfig: BillingConfig = {
-      features: Object.fromEntries(
-        features.map((f) => [f.code, toFeatureDef(f)]),
-      ),
-      plans: Object.fromEntries(
-        plans.map((p) => [
-          p.code,
-          {
-            name: p.name,
-            ...(p.description ? { description: p.description } : {}),
-            ...(p.consumptionModel
-              ? { consumptionModel: p.consumptionModel }
-              : {}),
-            ...(p.isFree ? { isFree: true } : {}),
-            ...(p.isPublic === false ? { isPublic: false } : {}),
-            ...(p.sortOrder ? { sortOrder: p.sortOrder } : {}),
-            ...(() => {
-              const planPrices = p.prices ?? [];
-              const defaultPrice = planPrices.find((pr) => pr.isDefault);
-              const defaultInterval =
-                defaultPrice?.billingInterval ?? planPrices[0]?.billingInterval;
-              return defaultInterval ? { defaultInterval } : {};
-            })(),
-            prices: (p.prices ?? []).map((pr) => ({
-              interval: pr.billingInterval,
-              amount: pr.price,
-              ...(pr.trialDays ? { trialDays: pr.trialDays } : {}),
-            })),
-          },
-        ]),
-      ),
-    };
+    const remoteAsConfig = remoteStateToBillingConfig(features, plans);
 
     const localAsRemote: RemoteState = {
       features: Object.entries(localConfig.features).map(([code, f]) => ({
         code,
         name: f.name,
         type: f.type,
+        description: f.description ?? null,
         unitName: "unitName" in f ? (f.unitName ?? null) : null,
       })),
       plans: Object.entries(localConfig.plans).map(([code, p]) => ({
         code,
         name: p.name,
+        description: p.description ?? null,
+        consumptionModel: p.consumptionModel ?? null,
+        isFree: p.isFree ?? false,
+        isPublic: p.isPublic ?? true,
+        sortOrder: p.sortOrder ?? 0,
         prices: p.prices.map((pr) => ({
           billingInterval: pr.interval,
-          price: pr.amount,
+          price: pr.amountInCents,
+          trialDays: pr.trialDays ?? 0,
+          isDefault: pr.interval === p.defaultInterval,
         })),
         features: p.features
-          ? Object.keys(p.features).map((featureCode) => ({
+          ? Object.entries(p.features).map(([featureCode, featureValue]) => ({
               code: featureCode,
+              enabled: typeof featureValue === "boolean" ? featureValue : true,
+              includedAmount:
+                typeof featureValue === "boolean"
+                  ? 0
+                  : (featureValue.included ?? 0),
+              unlimited:
+                typeof featureValue === "boolean"
+                  ? false
+                  : (featureValue.unlimited ?? false),
+              overage:
+                typeof featureValue !== "boolean" && featureValue.overage
+                  ? {
+                      enabled: true,
+                      unitPrice: featureValue.overage.unitPrice,
+                    }
+                  : { enabled: false, unitPrice: 0 },
             }))
           : [],
       })),

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -147,6 +147,19 @@ Examples:
         }
       }
 
+      if (!options.yes && agentMode) {
+        console.log(
+          JSON.stringify({
+            action: "blocked",
+            reason: localLoaded.parseError,
+            applied: false,
+            requiresYes: true,
+          }),
+        );
+        process.exitCode = 1;
+        return;
+      }
+
       fs.writeFileSync(outputPath, configContent, "utf8");
       if (agentMode) {
         console.log(JSON.stringify({ action: "overwrite", applied: true }));
@@ -181,6 +194,7 @@ Examples:
           price: pr.amountInCents,
           trialDays: pr.trialDays ?? 0,
           isDefault: pr.interval === p.defaultInterval,
+          inheritsFromPriceId: null,
         })),
         features: p.features
           ? Object.entries(p.features).map(([featureCode, featureValue]) => ({

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -3,29 +3,54 @@ import chalk from "chalk";
 import { Command } from "commander";
 import ora from "ora";
 import { apiRequest, BASE_URL } from "../utils/api";
-import { loadBillingConfig } from "../utils/config-loader";
+import {
+  BillingConfigValidationError,
+  loadBillingConfig,
+} from "../utils/config-loader";
 import { computeDiff, formatDiff } from "../utils/diff";
 import { isAgentMode, requireOrgContext } from "../utils/output";
 import { createSdkClient, fetchRemoteState } from "../utils/sdk";
 
-interface PushResponse {
+export interface PushResponse {
   success: boolean;
   features: {
     created: string[];
     updated: string[];
-    errors: Array<{ code: string; message: string }>;
+    errors: Array<{ code: string; path: string; message: string }>;
   };
   plans: {
     created: string[];
     updated: string[];
-    errors: Array<{ code: string; message: string }>;
+    errors: Array<{ code: string; path: string; message: string }>;
   };
+}
+
+function formatReceivedValue(received: unknown): string {
+  if (typeof received === "string") return received;
+  return JSON.stringify(received) ?? String(received);
 }
 
 interface PushOptions {
   yes?: boolean;
   dryRun?: boolean;
   output?: string;
+}
+
+export function createPushRequestBody(
+  config: Awaited<ReturnType<typeof loadBillingConfig>>["config"],
+  orgId: string,
+): Record<string, unknown> {
+  return {
+    config,
+    ...(orgId === "__from_api_key__" ? {} : { orgId }),
+  };
+}
+
+export function getPushExitCode(pushOutcome: PushResponse): 0 | 1 {
+  const hasErrors =
+    pushOutcome.features.errors.length > 0 ||
+    pushOutcome.plans.errors.length > 0;
+  return pushOutcome.success && !hasErrors ? 0 : 1;
 }
 
 export const pushCommand = new Command("push")
@@ -64,12 +89,26 @@ Examples:
         if (agentMode) {
           console.log(
             JSON.stringify({
-              error: { code: "config_invalid", message },
+              error: {
+                code: "config_invalid",
+                message,
+                ...(error instanceof BillingConfigValidationError
+                  ? { issues: error.issues }
+                  : {}),
+              },
             }),
           );
         } else {
           loadSpinner?.fail("Failed to load config");
           console.error(chalk.red(message));
+          if (error instanceof BillingConfigValidationError) {
+            for (const issue of error.issues) {
+              console.error(
+                chalk.red(`  ${issue.path}: ${issue.expected}`),
+                chalk.dim(`(received ${formatReceivedValue(issue.received)})`),
+              );
+            }
+          }
         }
         return null;
       },
@@ -171,12 +210,7 @@ Examples:
 
     const pushSpinner = agentMode ? null : ora("Pushing config...").start();
 
-    const pushBody: Record<string, unknown> = {
-      config: { features: config.features, plans: config.plans },
-    };
-    if (orgId !== "__from_api_key__") {
-      pushBody.orgId = orgId;
-    }
+    const pushBody = createPushRequestBody(config, orgId);
 
     const pushResult = await apiRequest<PushResponse>(
       `${BASE_URL}/api/cli/push`,
@@ -189,26 +223,34 @@ Examples:
       } else {
         pushSpinner?.fail("Push failed");
         console.error(chalk.red("Error:"), pushResult.error?.message);
+        for (const issue of pushResult.error?.issues ?? []) {
+          console.error(
+            chalk.red(`  ${issue.path}: ${issue.expected}`),
+            chalk.dim(`(received ${formatReceivedValue(issue.received)})`),
+          );
+        }
       }
       process.exit(1);
     }
 
     const pushOutcome = pushResult.data;
-
-    if (agentMode) {
-      console.log(JSON.stringify({ diff, applied: true, result: pushOutcome }));
-      return;
-    }
-
     const errors = [
       ...pushOutcome.features.errors,
       ...pushOutcome.plans.errors,
     ];
 
+    if (agentMode) {
+      console.log(JSON.stringify({ diff, applied: true, result: pushOutcome }));
+      if (getPushExitCode(pushOutcome) !== 0) process.exit(1);
+      return;
+    }
+
     if (errors.length > 0) {
       pushSpinner?.warn("Push completed with errors");
       for (const error of errors) {
-        console.log(chalk.red(`  ✗ ${error.code}: ${error.message}`));
+        console.log(
+          chalk.red(`  ✗ ${error.path} (${error.code}): ${error.message}`),
+        );
       }
     } else {
       pushSpinner?.succeed("Push complete");
@@ -240,4 +282,6 @@ Examples:
         ),
       );
     }
+
+    if (getPushExitCode(pushOutcome) !== 0) process.exit(1);
   });

--- a/packages/cli/src/commands/resources/param-types.ts
+++ b/packages/cli/src/commands/resources/param-types.ts
@@ -46,7 +46,7 @@ export function parsePositiveInteger(value: string): number {
   return number;
 }
 
-function parsePostgresInteger(value: string): number {
+export function parsePostgresInteger(value: string): number {
   const number = parseSafeInteger(value);
   if (number < -2_147_483_648 || number > 2_147_483_647) {
     throw new Error(`Invalid PostgreSQL integer: ${value}`);

--- a/packages/cli/src/commands/resources/param-types.ts
+++ b/packages/cli/src/commands/resources/param-types.ts
@@ -8,10 +8,66 @@ export function parseJson(value: string): unknown {
 
 export function parseNumber(value: string): number {
   const num = Number(value);
-  if (Number.isNaN(num)) {
-    throw new Error(`Invalid number: ${value}`);
+  if (!Number.isFinite(num)) {
+    throw new Error(`Invalid finite number: ${value}`);
   }
   return num;
+}
+
+export function parseSafeInteger(value: string): number {
+  const number = parseNumber(value);
+  if (!Number.isSafeInteger(number)) {
+    throw new Error(`Invalid safe integer: ${value}`);
+  }
+  return number;
+}
+
+export function parseNonNegativeNumber(value: string): number {
+  const number = parseNumber(value);
+  if (number < 0) {
+    throw new Error(`Invalid non-negative number: ${value}`);
+  }
+  return number;
+}
+
+export function parseNonNegativeInteger(value: string): number {
+  const number = parseSafeInteger(value);
+  if (number < 0) {
+    throw new Error(`Invalid non-negative integer: ${value}`);
+  }
+  return number;
+}
+
+export function parsePositiveInteger(value: string): number {
+  const number = parseSafeInteger(value);
+  if (number <= 0) {
+    throw new Error(`Invalid positive integer: ${value}`);
+  }
+  return number;
+}
+
+function parsePostgresInteger(value: string): number {
+  const number = parseSafeInteger(value);
+  if (number < -2_147_483_648 || number > 2_147_483_647) {
+    throw new Error(`Invalid PostgreSQL integer: ${value}`);
+  }
+  return number;
+}
+
+export function parseNonNegativePostgresInteger(value: string): number {
+  const number = parsePostgresInteger(value);
+  if (number < 0) {
+    throw new Error(`Invalid non-negative PostgreSQL integer: ${value}`);
+  }
+  return number;
+}
+
+export function parsePositivePostgresInteger(value: string): number {
+  const number = parsePostgresInteger(value);
+  if (number <= 0) {
+    throw new Error(`Invalid positive PostgreSQL integer: ${value}`);
+  }
+  return number;
 }
 
 export function parseBool(value: string): boolean {

--- a/packages/cli/src/commands/resources/registry.ts
+++ b/packages/cli/src/commands/resources/registry.ts
@@ -1,5 +1,14 @@
 import type { ResourceDef } from "./factory";
-import { parseBool, parseJson, parseNumber } from "./param-types";
+import {
+  parseBool,
+  parseJson,
+  parseNonNegativeInteger,
+  parseNonNegativeNumber,
+  parseNonNegativePostgresInteger,
+  parsePositiveInteger,
+  parsePositivePostgresInteger,
+  parseSafeInteger,
+} from "./param-types";
 
 const customersResource: ResourceDef = {
   name: "customers",
@@ -138,7 +147,7 @@ const customersResource: ResourceDef = {
         {
           flag: "--limit <n>",
           description: "Max results",
-          parse: parseNumber,
+          parse: parsePositiveInteger,
           sdkKey: "limit",
         },
         {
@@ -206,8 +215,8 @@ const subscriptionsResource: ResourceDef = {
         },
         {
           flag: "--custom-trial-days <n>",
-          description: "Override the catalog trial duration",
-          parse: parseNumber,
+          description: "Override the catalog trial duration in whole days",
+          parse: parseNonNegativeInteger,
           sdkKey: "customTrialDays",
         },
         {
@@ -254,7 +263,9 @@ const subscriptionsResource: ResourceDef = {
           params.initialSeats = parseJson(options.initialSeats);
         if (options.skipTrial) params.skipTrial = parseBool(options.skipTrial);
         if (options.customTrialDays)
-          params.customTrialDays = parseNumber(options.customTrialDays);
+          params.customTrialDays = parseNonNegativeInteger(
+            options.customTrialDays,
+          );
         if (options.offerId) params.offerId = options.offerId;
         if (options.promoCode) params.promoCode = options.promoCode;
         if (options.provider) params.provider = options.provider;
@@ -484,9 +495,10 @@ const subscriptionsResource: ResourceDef = {
         },
         {
           flag: "--amount <amount>",
-          description: "Amount (positive adds, negative subtracts)",
+          description:
+            "Signed integer: rate scale for balance, whole units for credits",
           required: true,
-          parse: parseNumber,
+          parse: parseSafeInteger,
           sdkKey: "amount",
         },
         {
@@ -513,9 +525,9 @@ const subscriptionsResource: ResourceDef = {
         },
         {
           flag: "--amount <amount>",
-          description: "Amount to top up",
+          description: "Positive amount in USD cents (499 = $4.99)",
           required: true,
-          parse: parseNumber,
+          parse: parsePositiveInteger,
           sdkKey: "amount",
         },
       ],
@@ -716,8 +728,8 @@ const plansResource: ResourceDef = {
         },
         {
           flag: "--included-amount <n>",
-          description: "Included amount",
-          parse: parseNumber,
+          description: "Included whole units",
+          parse: parseNonNegativeInteger,
           sdkKey: "includedAmount",
         },
         {
@@ -734,8 +746,8 @@ const plansResource: ResourceDef = {
         },
         {
           flag: "--overage-unit-price <n>",
-          description: "Overage unit price (fixed pricing)",
-          parse: parseNumber,
+          description: "Overage price in rate scale (10000 = $1.00)",
+          parse: parseNonNegativeInteger,
           sdkKey: "overage.unitPrice",
         },
         {
@@ -745,14 +757,14 @@ const plansResource: ResourceDef = {
         },
         {
           flag: "--margin <n>",
-          description: "Margin percentage (ai_model pricing)",
-          parse: parseNumber,
+          description: "Margin in basis points (2000 = 20%)",
+          parse: parseNonNegativeInteger,
           sdkKey: "margin",
         },
         {
           flag: "--credits-per-unit <n>",
-          description: "Credits per unit",
-          parse: parseNumber,
+          description: "Whole credits consumed per unit",
+          parse: parseNonNegativeInteger,
           sdkKey: "creditsPerUnit",
         },
       ],
@@ -781,8 +793,8 @@ const plansResource: ResourceDef = {
         },
         {
           flag: "--included-amount <n>",
-          description: "Included amount",
-          parse: parseNumber,
+          description: "Included whole units",
+          parse: parseNonNegativeInteger,
           sdkKey: "includedAmount",
         },
         {
@@ -799,14 +811,14 @@ const plansResource: ResourceDef = {
         },
         {
           flag: "--overage-unit-price <n>",
-          description: "Overage unit price (fixed pricing)",
-          parse: parseNumber,
+          description: "Overage price in rate scale (10000 = $1.00)",
+          parse: parseNonNegativeInteger,
           sdkKey: "overage.unitPrice",
         },
         {
           flag: "--credits-per-unit <n>",
-          description: "Credits per unit",
-          parse: parseNumber,
+          description: "Whole credits consumed per unit",
+          parse: parseNonNegativeInteger,
           sdkKey: "creditsPerUnit",
         },
       ],
@@ -848,8 +860,8 @@ const plansResource: ResourceDef = {
         },
         {
           flag: "--price <n>",
-          description: "Price in cents",
-          parse: parseNumber,
+          description: "Price in USD cents (499 = $4.99)",
+          parse: parseNonNegativeInteger,
           sdkKey: "price",
         },
         {
@@ -859,8 +871,8 @@ const plansResource: ResourceDef = {
         },
         {
           flag: "--trial-days <n>",
-          description: "Trial days",
-          parse: parseNumber,
+          description: "Trial duration in whole days",
+          parse: parseNonNegativePostgresInteger,
           sdkKey: "trialDays",
         },
         {
@@ -871,14 +883,14 @@ const plansResource: ResourceDef = {
         },
         {
           flag: "--included-balance <n>",
-          description: "Included balance",
-          parse: parseNumber,
+          description: "Included balance in USD cents (1000 = $10.00)",
+          parse: parseNonNegativeInteger,
           sdkKey: "includedBalance",
         },
         {
           flag: "--included-credits <n>",
-          description: "Included credits",
-          parse: parseNumber,
+          description: "Included whole credits",
+          parse: parseNonNegativeInteger,
           sdkKey: "includedCredits",
         },
         {
@@ -913,8 +925,8 @@ const plansResource: ResourceDef = {
         },
         {
           flag: "--price <n>",
-          description: "Price in cents",
-          parse: parseNumber,
+          description: "Price in USD cents (499 = $4.99)",
+          parse: parseNonNegativeInteger,
           sdkKey: "price",
         },
         {
@@ -925,20 +937,20 @@ const plansResource: ResourceDef = {
         },
         {
           flag: "--trial-days <n>",
-          description: "Trial days",
-          parse: parseNumber,
+          description: "Trial duration in whole days",
+          parse: parseNonNegativePostgresInteger,
           sdkKey: "trialDays",
         },
         {
           flag: "--included-balance <n>",
-          description: "Included balance",
-          parse: parseNumber,
+          description: "Included balance in USD cents (1000 = $10.00)",
+          parse: parseNonNegativeInteger,
           sdkKey: "includedBalance",
         },
         {
           flag: "--included-credits <n>",
-          description: "Included credits",
-          parse: parseNumber,
+          description: "Included whole credits",
+          parse: parseNonNegativeInteger,
           sdkKey: "includedCredits",
         },
         {
@@ -1198,7 +1210,7 @@ const seatsResource: ResourceDef = {
         {
           flag: "--count <n>",
           description: "Number of seats to add (defaults to 1)",
-          parse: parseNumber,
+          parse: parsePositiveInteger,
           sdkKey: "count",
         },
       ],
@@ -1222,7 +1234,7 @@ const seatsResource: ResourceDef = {
         {
           flag: "--count <n>",
           description: "Number of seats to remove (defaults to 1)",
-          parse: parseNumber,
+          parse: parsePositiveInteger,
           sdkKey: "count",
         },
       ],
@@ -1247,7 +1259,7 @@ const seatsResource: ResourceDef = {
           flag: "--count <n>",
           description: "Exact seat count",
           required: true,
-          parse: parseNumber,
+          parse: parseNonNegativeInteger,
           sdkKey: "count",
         },
       ],
@@ -1328,7 +1340,7 @@ const usageResource: ResourceDef = {
         {
           flag: "--value <n>",
           description: "Usage value (standard tracking)",
-          parse: parseNumber,
+          parse: parseNonNegativeNumber,
           sdkKey: "value",
         },
         {
@@ -1339,25 +1351,25 @@ const usageResource: ResourceDef = {
         {
           flag: "--input-tokens <n>",
           description: "Input tokens (model tracking)",
-          parse: parseNumber,
+          parse: parseNonNegativeInteger,
           sdkKey: "inputTokens",
         },
         {
           flag: "--output-tokens <n>",
           description: "Output tokens (model tracking)",
-          parse: parseNumber,
+          parse: parseNonNegativeInteger,
           sdkKey: "outputTokens",
         },
         {
           flag: "--cache-read-tokens <n>",
           description: "Cache read tokens (model tracking)",
-          parse: parseNumber,
+          parse: parseNonNegativeInteger,
           sdkKey: "cacheReadTokens",
         },
         {
           flag: "--cache-write-tokens <n>",
           description: "Cache write tokens (model tracking)",
-          parse: parseNumber,
+          parse: parseNonNegativeInteger,
           sdkKey: "cacheWriteTokens",
         },
         {
@@ -1390,14 +1402,19 @@ const usageResource: ResourceDef = {
 
         if (options.model) {
           params.model = options.model;
-          params.inputTokens = parseNumber(options.inputTokens);
-          params.outputTokens = parseNumber(options.outputTokens);
+          params.inputTokens = parseNonNegativeInteger(options.inputTokens);
+          params.outputTokens = parseNonNegativeInteger(options.outputTokens);
           if (options.cacheReadTokens)
-            params.cacheReadTokens = parseNumber(options.cacheReadTokens);
+            params.cacheReadTokens = parseNonNegativeInteger(
+              options.cacheReadTokens,
+            );
           if (options.cacheWriteTokens)
-            params.cacheWriteTokens = parseNumber(options.cacheWriteTokens);
+            params.cacheWriteTokens = parseNonNegativeInteger(
+              options.cacheWriteTokens,
+            );
         } else {
-          if (options.value) params.value = parseNumber(options.value);
+          if (options.value)
+            params.value = parseNonNegativeNumber(options.value);
         }
 
         return params;
@@ -1422,7 +1439,7 @@ const usageResource: ResourceDef = {
         {
           flag: "--quantity <n>",
           description: "Quantity to check",
-          parse: parseNumber,
+          parse: parsePositiveInteger,
           sdkKey: "quantity",
         },
       ],
@@ -1487,7 +1504,7 @@ const addonsResource: ResourceDef = {
         {
           flag: "--limit <n>",
           description: "Max results",
-          parse: parseNumber,
+          parse: parsePositiveInteger,
           sdkKey: "limit",
         },
         {
@@ -1521,9 +1538,9 @@ const addonsResource: ResourceDef = {
         },
         {
           flag: "--base-price <n>",
-          description: "Base price in cents",
+          description: "Base price in USD cents (499 = $4.99)",
           required: true,
-          parse: parseNumber,
+          parse: parseNonNegativeInteger,
           sdkKey: "basePrice",
         },
         {
@@ -1547,19 +1564,19 @@ const addonsResource: ResourceDef = {
         {
           flag: "--included-units <n>",
           description: "Included units (metered)",
-          parse: parseNumber,
+          parse: parseNonNegativeInteger,
           sdkKey: "includedUnits",
         },
         {
           flag: "--overage-rate <n>",
-          description: "Overage rate (metered/balance)",
-          parse: parseNumber,
+          description: "Overage rate scale (10000 = $1.00)",
+          parse: parseNonNegativeInteger,
           sdkKey: "overageRate",
         },
         {
           flag: "--credit-cost <n>",
           description: "Credit cost (credits)",
-          parse: parseNumber,
+          parse: parseNonNegativeInteger,
           sdkKey: "creditCost",
         },
       ],
@@ -1586,20 +1603,20 @@ const addonsResource: ResourceDef = {
         },
         {
           flag: "--base-price <n>",
-          description: "Base price in cents",
-          parse: parseNumber,
+          description: "Base price in USD cents (499 = $4.99)",
+          parse: parseNonNegativeInteger,
           sdkKey: "basePrice",
         },
         {
           flag: "--included-units <n>",
           description: "Included units",
-          parse: parseNumber,
+          parse: parseNonNegativeInteger,
           sdkKey: "includedUnits",
         },
         {
           flag: "--overage-rate <n>",
-          description: "Overage rate",
-          parse: parseNumber,
+          description: "Overage rate scale (10000 = $1.00)",
+          parse: parseNonNegativeInteger,
           sdkKey: "overageRate",
         },
       ],
@@ -1643,14 +1660,14 @@ const creditPacksResource: ResourceDef = {
           flag: "--credits <n>",
           description: "Number of credits",
           required: true,
-          parse: parseNumber,
+          parse: parsePositiveInteger,
           sdkKey: "credits",
         },
         {
           flag: "--price <n>",
-          description: "Price in cents",
+          description: "Price in USD cents (499 = $4.99)",
           required: true,
-          parse: parseNumber,
+          parse: parseNonNegativeInteger,
           sdkKey: "price",
         },
         {
@@ -1689,13 +1706,13 @@ const creditPacksResource: ResourceDef = {
         {
           flag: "--credits <n>",
           description: "Number of credits",
-          parse: parseNumber,
+          parse: parsePositiveInteger,
           sdkKey: "credits",
         },
         {
           flag: "--price <n>",
-          description: "Price in cents",
-          parse: parseNumber,
+          description: "Price in USD cents (499 = $4.99)",
+          parse: parseNonNegativeInteger,
           sdkKey: "price",
         },
         {
@@ -1733,7 +1750,7 @@ const webhooksResource: ResourceDef = {
         {
           flag: "--limit <n>",
           description: "Max results",
-          parse: parseNumber,
+          parse: parsePositiveInteger,
           sdkKey: "limit",
         },
         {
@@ -1864,7 +1881,7 @@ const apiKeysResource: ResourceDef = {
         {
           flag: "--limit <n>",
           description: "Max results",
-          parse: parseNumber,
+          parse: parsePositiveInteger,
           sdkKey: "limit",
         },
         {
@@ -1886,8 +1903,8 @@ const apiKeysResource: ResourceDef = {
         },
         {
           flag: "--expires-in-days <n>",
-          description: "Expiration in days",
-          parse: parseNumber,
+          description: "Expiration in whole days",
+          parse: parsePositiveInteger,
           sdkKey: "expiresInDays",
         },
       ],
@@ -1934,7 +1951,7 @@ const invoicesResource: ResourceDef = {
         {
           flag: "--limit <n>",
           description: "Max results",
-          parse: parseNumber,
+          parse: parsePositiveInteger,
           sdkKey: "limit",
         },
         {
@@ -1968,9 +1985,9 @@ const invoicesResource: ResourceDef = {
         },
         {
           flag: "--amount <n>",
-          description: "Amount in cents (negative for credit)",
+          description: "Signed amount in USD cents (negative for credit)",
           required: true,
-          parse: parseNumber,
+          parse: parseSafeInteger,
           sdkKey: "amount",
         },
         {
@@ -2053,7 +2070,7 @@ const transactionsResource: ResourceDef = {
         {
           flag: "--limit <n>",
           description: "Max results",
-          parse: parseNumber,
+          parse: parsePositiveInteger,
           sdkKey: "limit",
         },
         {
@@ -2114,7 +2131,7 @@ const promoCodesResource: ResourceDef = {
         {
           flag: "--limit <n>",
           description: "Max results",
-          parse: parseNumber,
+          parse: parsePositiveInteger,
           sdkKey: "limit",
         },
         {
@@ -2160,7 +2177,7 @@ const promoCodesResource: ResourceDef = {
         {
           flag: "--max-redemptions <n>",
           description: "Maximum number of redemptions",
-          parse: parseNumber,
+          parse: parsePositivePostgresInteger,
           sdkKey: "maxRedemptions",
         },
         {
@@ -2194,7 +2211,7 @@ const promoCodesResource: ResourceDef = {
         {
           flag: "--max-redemptions <n>",
           description: "Maximum number of redemptions",
-          parse: parseNumber,
+          parse: parsePositivePostgresInteger,
           sdkKey: "maxRedemptions",
         },
         {
@@ -2231,7 +2248,7 @@ const offersResource: ResourceDef = {
         {
           flag: "--limit <n>",
           description: "Max results",
-          parse: parseNumber,
+          parse: parsePositiveInteger,
           sdkKey: "limit",
         },
         {
@@ -2467,7 +2484,7 @@ const planGroupsResource: ResourceDef = {
         {
           flag: "--limit <n>",
           description: "Max results",
-          parse: parseNumber,
+          parse: parsePositiveInteger,
           sdkKey: "limit",
         },
         {
@@ -2571,7 +2588,7 @@ const planGroupsResource: ResourceDef = {
         {
           flag: "--sort-order <n>",
           description: "Sort order",
-          parse: parseNumber,
+          parse: parseNonNegativePostgresInteger,
           sdkKey: "sortOrder",
         },
       ],
@@ -2628,9 +2645,9 @@ const paymentsResource: ResourceDef = {
       params: [
         {
           flag: "--amount <n>",
-          description: "Amount in cents",
+          description: "Positive amount in currency minor units",
           required: true,
-          parse: parseNumber,
+          parse: parsePositiveInteger,
           sdkKey: "amount",
         },
         {
@@ -2675,9 +2692,9 @@ const paymentsResource: ResourceDef = {
         },
         {
           flag: "--amount <n>",
-          description: "Amount in cents",
+          description: "Positive amount in currency minor units",
           required: true,
-          parse: parseNumber,
+          parse: parsePositiveInteger,
           sdkKey: "amount",
         },
         {
@@ -2724,7 +2741,7 @@ const paymentsResource: ResourceDef = {
         {
           flag: "--limit <n>",
           description: "Max results",
-          parse: parseNumber,
+          parse: parsePositiveInteger,
           sdkKey: "limit",
         },
         {
@@ -2760,9 +2777,9 @@ const payoutsResource: ResourceDef = {
       params: [
         {
           flag: "--amount <n>",
-          description: "Amount in cents (USD, minimum 1000)",
+          description: "Amount in USD cents (minimum 1000 = $10.00)",
           required: true,
-          parse: parseNumber,
+          parse: parsePositiveInteger,
           sdkKey: "amount",
         },
         {
@@ -2875,8 +2892,8 @@ const testClockResource: ResourceDef = {
       params: [
         {
           flag: "--advance-days <n>",
-          description: "Days to move the clock forward",
-          parse: parseNumber,
+          description: "Positive whole days to move the clock forward",
+          parse: parsePositiveInteger,
           sdkKey: "advanceDays",
         },
         {
@@ -2923,7 +2940,7 @@ const quotaResource: ResourceDef = {
         {
           flag: "--count <n>",
           description: "Amount to add (defaults to 1)",
-          parse: parseNumber,
+          parse: parsePositiveInteger,
           sdkKey: "count",
         },
         {
@@ -2948,7 +2965,7 @@ const quotaResource: ResourceDef = {
           flag: "--count <n>",
           description: "Exact allowance value",
           required: true,
-          parse: parseNumber,
+          parse: parseNonNegativeInteger,
           sdkKey: "count",
         },
         {
@@ -2992,7 +3009,7 @@ const quotaResource: ResourceDef = {
         {
           flag: "--count <n>",
           description: "Amount to remove (defaults to 1)",
-          parse: parseNumber,
+          parse: parsePositiveInteger,
           sdkKey: "count",
         },
         {

--- a/packages/cli/src/commands/resources/registry.ts
+++ b/packages/cli/src/commands/resources/registry.ts
@@ -7,6 +7,7 @@ import {
   parseNonNegativePostgresInteger,
   parsePositiveInteger,
   parsePositivePostgresInteger,
+  parsePostgresInteger,
   parseSafeInteger,
 } from "./param-types";
 
@@ -216,7 +217,7 @@ const subscriptionsResource: ResourceDef = {
         {
           flag: "--custom-trial-days <n>",
           description: "Override the catalog trial duration in whole days",
-          parse: parseNonNegativeInteger,
+          parse: parseNonNegativePostgresInteger,
           sdkKey: "customTrialDays",
         },
         {
@@ -263,7 +264,7 @@ const subscriptionsResource: ResourceDef = {
           params.initialSeats = parseJson(options.initialSeats);
         if (options.skipTrial) params.skipTrial = parseBool(options.skipTrial);
         if (options.customTrialDays)
-          params.customTrialDays = parseNonNegativeInteger(
+          params.customTrialDays = parseNonNegativePostgresInteger(
             options.customTrialDays,
           );
         if (options.offerId) params.offerId = options.offerId;
@@ -758,13 +759,13 @@ const plansResource: ResourceDef = {
         {
           flag: "--margin <n>",
           description: "Margin in basis points (2000 = 20%)",
-          parse: parseNonNegativeInteger,
+          parse: parseNonNegativePostgresInteger,
           sdkKey: "margin",
         },
         {
           flag: "--credits-per-unit <n>",
           description: "Whole credits consumed per unit",
-          parse: parseNonNegativeInteger,
+          parse: parseNonNegativePostgresInteger,
           sdkKey: "creditsPerUnit",
         },
       ],
@@ -818,7 +819,7 @@ const plansResource: ResourceDef = {
         {
           flag: "--credits-per-unit <n>",
           description: "Whole credits consumed per unit",
-          parse: parseNonNegativeInteger,
+          parse: parseNonNegativePostgresInteger,
           sdkKey: "creditsPerUnit",
         },
       ],
@@ -890,7 +891,7 @@ const plansResource: ResourceDef = {
         {
           flag: "--included-credits <n>",
           description: "Included whole credits",
-          parse: parseNonNegativeInteger,
+          parse: parseNonNegativePostgresInteger,
           sdkKey: "includedCredits",
         },
         {
@@ -950,7 +951,7 @@ const plansResource: ResourceDef = {
         {
           flag: "--included-credits <n>",
           description: "Included whole credits",
-          parse: parseNonNegativeInteger,
+          parse: parseNonNegativePostgresInteger,
           sdkKey: "includedCredits",
         },
         {
@@ -1576,7 +1577,7 @@ const addonsResource: ResourceDef = {
         {
           flag: "--credit-cost <n>",
           description: "Credit cost (credits)",
-          parse: parseNonNegativeInteger,
+          parse: parseNonNegativePostgresInteger,
           sdkKey: "creditCost",
         },
       ],
@@ -2588,7 +2589,7 @@ const planGroupsResource: ResourceDef = {
         {
           flag: "--sort-order <n>",
           description: "Sort order",
-          parse: parseNonNegativePostgresInteger,
+          parse: parsePostgresInteger,
           sdkKey: "sortOrder",
         },
       ],

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { BILLING_CONFIG_SCHEMA_VERSION } from "@commet/node";
 import chalk from "chalk";
 import { Command } from "commander";
 import packageJson from "../package.json" with { type: "json" };
@@ -154,6 +155,20 @@ function printAgentInfo() {
     config: {
       exists: configPath !== null,
       path: configPath?.split("/").pop() ?? null,
+      contract: {
+        schemaVersion: BILLING_CONFIG_SCHEMA_VERSION,
+        jsonSchemaExport: "@commet/node.BILLING_CONFIG_JSON_SCHEMA",
+        basePrice: {
+          field: "amountInCents",
+          unit: "USD minor units",
+          example: { amountInCents: 499, formatted: "$4.99" },
+        },
+        overageUnitPrice: {
+          unit: "rate scale",
+          example: { unitPrice: 10_000, formatted: "$1.00 per unit" },
+        },
+        migrate: "Run `commet pull --yes` to regenerate an older config",
+      },
     },
     mcp: {
       url: "https://commet.co/mcp",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -157,7 +157,9 @@ function printAgentInfo() {
       path: configPath?.split("/").pop() ?? null,
       contract: {
         schemaVersion: BILLING_CONFIG_SCHEMA_VERSION,
-        jsonSchemaExport: "@commet/node.BILLING_CONFIG_JSON_SCHEMA",
+        runtimeSchemaExport: "@commet/node.BillingConfigSchema",
+        structuralJsonSchemaExport:
+          "@commet/node.BILLING_CONFIG_STRUCTURAL_JSON_SCHEMA",
         basePrice: {
           field: "amountInCents",
           unit: "USD minor units",
@@ -167,7 +169,8 @@ function printAgentInfo() {
           unit: "rate scale",
           example: { unitPrice: 10_000, formatted: "$1.00 per unit" },
         },
-        migrate: "Run `commet pull --yes` to regenerate an older config",
+        migrate:
+          "Commit or back up commet.config.ts; add schemaVersion: 1; rename integer amount values to amountInCents or convert decimal USD amounts to exact cents; then run `commet push --dry-run`.",
       },
     },
     mcp: {

--- a/packages/cli/src/utils/api.ts
+++ b/packages/cli/src/utils/api.ts
@@ -1,12 +1,23 @@
 import { loadAuth } from "./config";
 import { getClientInfoHeader, getUserAgent, markApiRequest } from "./telemetry";
 
+export interface ApiRequestError {
+  code: string;
+  message: string;
+  issues?: Array<{
+    code: string;
+    path: string;
+    expected: string;
+    received: unknown;
+  }>;
+}
+
 export const BASE_URL = "https://commet.co";
 
 export async function apiRequest<T>(
   endpoint: string,
   options: RequestInit = {},
-): Promise<{ data?: T; error?: { code: string; message: string } }> {
+): Promise<{ data?: T; error?: ApiRequestError }> {
   const apiKey = process.env.COMMET_API_KEY;
   const auth = apiKey ? null : loadAuth();
 
@@ -39,6 +50,7 @@ export async function apiRequest<T>(
         message?: string;
         error?: string;
         code?: string;
+        issues?: ApiRequestError["issues"];
       };
       return {
         error: {
@@ -47,6 +59,7 @@ export async function apiRequest<T>(
             errorData.message ??
             errorData.error ??
             `Request failed with status ${response.status}`,
+          ...(errorData.issues ? { issues: errorData.issues } : {}),
         },
       };
     }

--- a/packages/cli/src/utils/config-contract.test.ts
+++ b/packages/cli/src/utils/config-contract.test.ts
@@ -1,0 +1,271 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { BillingConfig, Feature, Plan } from "@commet/node";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  createPushRequestBody,
+  getPushExitCode,
+  type PushResponse,
+} from "../commands/push";
+import {
+  parseNonNegativeInteger,
+  parseNonNegativeNumber,
+  parseNonNegativePostgresInteger,
+  parseNumber,
+  parsePositiveInteger,
+  parsePositivePostgresInteger,
+  parseSafeInteger,
+} from "../commands/resources/param-types";
+import {
+  BillingConfigValidationError,
+  loadBillingConfig,
+} from "./config-loader";
+import { computeDiff, formatDiff, type RemoteState } from "./diff";
+import { generateConfigFile } from "./generator";
+
+const temporaryDirectories: string[] = [];
+
+function config(): BillingConfig {
+  return {
+    schemaVersion: 1,
+    features: {},
+    plans: {
+      pro: {
+        name: "Pro",
+        defaultInterval: "monthly",
+        prices: [{ interval: "monthly", amountInCents: 499 }],
+      },
+    },
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("config generation and sync", () => {
+  test("generates a versioned 499-cent config that loads unchanged", async () => {
+    const features: Feature[] = [];
+    const plans: Plan[] = [
+      {
+        id: "plan_123",
+        code: "pro",
+        name: "Pro",
+        description: null,
+        consumptionModel: null,
+        isDefault: false,
+        isFree: false,
+        isPublic: true,
+        blockOnExhaustion: null,
+        sortOrder: 0,
+        planGroupId: null,
+        metadata: null,
+        createdAt: "2026-08-06T00:00:00.000Z",
+        updatedAt: "2026-08-06T00:00:00.000Z",
+        features: [],
+        prices: [
+          {
+            id: "price_123",
+            billingInterval: "monthly",
+            price: 499,
+            isDefault: true,
+            trialDays: 0,
+            includedBalance: null,
+            includedCredits: null,
+            offerId: null,
+            inheritsFromPriceId: null,
+            metadata: {},
+            marketPrices: [],
+            regionalPrices: [],
+          },
+          {
+            id: "price_456",
+            billingInterval: "monthly",
+            price: 699,
+            isDefault: false,
+            trialDays: 0,
+            includedBalance: null,
+            includedCredits: null,
+            offerId: null,
+            inheritsFromPriceId: "price_base",
+            metadata: {},
+            marketPrices: [],
+            regionalPrices: [],
+          },
+        ],
+        exchangeRates: [],
+        object: "plan",
+        livemode: false,
+      },
+    ];
+    const generated = generateConfigFile(features, plans);
+    const directory = await mkdtemp(
+      path.join(process.cwd(), ".commet-config-test-"),
+    );
+    temporaryDirectories.push(directory);
+    await writeFile(path.join(directory, "commet.config.ts"), generated);
+
+    const loaded = await loadBillingConfig(directory);
+
+    expect(loaded.config.schemaVersion).toBe(1);
+    expect(loaded.config.plans.pro?.prices[0]?.amountInCents).toBe(499);
+    expect(loaded.config.plans.pro?.prices).toHaveLength(1);
+    expect(generated).not.toContain("amount: 499");
+  });
+
+  test("rejects the old fractional amount locally", async () => {
+    const directory = await mkdtemp(
+      path.join(process.cwd(), ".commet-config-test-"),
+    );
+    temporaryDirectories.push(directory);
+    await writeFile(
+      path.join(directory, "commet.config.ts"),
+      `export default { schemaVersion: 1, features: {}, plans: { pro: { name: "Pro", defaultInterval: "monthly", prices: [{ interval: "monthly", amount: 4.99 }] } } };`,
+    );
+
+    const error = await loadBillingConfig(directory).catch(
+      (loadError: unknown) => loadError,
+    );
+
+    expect(error).toBeInstanceOf(BillingConfigValidationError);
+    if (!(error instanceof BillingConfigValidationError)) {
+      throw new Error("Expected billing config validation to fail");
+    }
+    expect(error.issues).toContainEqual(
+      expect.objectContaining({
+        code: "config_price_field_renamed",
+        path: "config.plans.pro.prices[0].amount",
+        received: 4.99,
+      }),
+    );
+  });
+
+  test("renders base-price diffs at cent scale", () => {
+    const remoteState: RemoteState = {
+      features: [],
+      plans: [
+        {
+          code: "pro",
+          name: "Pro",
+          description: null,
+          consumptionModel: null,
+          isFree: false,
+          isPublic: true,
+          sortOrder: 0,
+          prices: [
+            {
+              billingInterval: "monthly",
+              price: 500,
+              trialDays: 0,
+              isDefault: true,
+            },
+          ],
+          features: [],
+        },
+      ],
+    };
+
+    expect(formatDiff(computeDiff(config(), remoteState))).toContain(
+      "$5.00 → $4.99",
+    );
+  });
+
+  test("detects non-price config field changes before push", () => {
+    const localConfig = config();
+    localConfig.plans.pro!.prices[0]!.trialDays = 14;
+    const remoteState: RemoteState = {
+      features: [],
+      plans: [
+        {
+          code: "pro",
+          name: "Pro",
+          description: null,
+          consumptionModel: null,
+          isFree: false,
+          isPublic: true,
+          sortOrder: 0,
+          prices: [
+            {
+              billingInterval: "monthly",
+              price: 499,
+              trialDays: 0,
+              isDefault: true,
+            },
+          ],
+          features: [],
+        },
+      ],
+    };
+
+    expect(
+      computeDiff(localConfig, remoteState).plans.changes[0],
+    ).toMatchObject({
+      action: "update",
+      changes: ["price monthly trialDays: 0 → 14"],
+    });
+  });
+
+  test("sends the complete versioned config", () => {
+    expect(createPushRequestBody(config(), "org_123")).toEqual({
+      config: config(),
+      orgId: "org_123",
+    });
+  });
+});
+
+describe("push exit semantics", () => {
+  function response(): PushResponse {
+    return {
+      success: true,
+      features: { created: [], updated: [], errors: [] },
+      plans: { created: [], updated: [], errors: [] },
+    };
+  }
+
+  test("returns zero only for a complete success", () => {
+    expect(getPushExitCode(response())).toBe(0);
+  });
+
+  test("returns non-zero for explicit and per-item failures", () => {
+    const rejected = response();
+    rejected.success = false;
+    expect(getPushExitCode(rejected)).toBe(1);
+
+    const partial = response();
+    partial.plans.errors.push({
+      code: "plan_price_update_failed",
+      path: "config.plans.pro.prices[0]",
+      message: "Failed to update price",
+    });
+    expect(getPushExitCode(partial)).toBe(1);
+  });
+});
+
+describe("resource number parsing", () => {
+  test.each([
+    "NaN",
+    "Infinity",
+    "-Infinity",
+  ])("rejects non-finite %s", (value) => {
+    expect(() => parseNumber(value)).toThrow();
+  });
+
+  test("enforces integer domains", () => {
+    expect(() => parseSafeInteger("4.99")).toThrow();
+    expect(() =>
+      parseSafeInteger(String(Number.MAX_SAFE_INTEGER + 1)),
+    ).toThrow();
+    expect(() => parseNonNegativeInteger("-1")).toThrow();
+    expect(() => parseNonNegativeNumber("-0.1")).toThrow();
+    expect(parseNonNegativeNumber("4.99")).toBe(4.99);
+    expect(() => parsePositiveInteger("0")).toThrow();
+    expect(parseNonNegativeInteger("499")).toBe(499);
+    expect(() => parseNonNegativePostgresInteger("2147483648")).toThrow();
+    expect(() => parsePositivePostgresInteger("2147483648")).toThrow();
+    expect(parseNonNegativePostgresInteger("2147483647")).toBe(2_147_483_647);
+  });
+});

--- a/packages/cli/src/utils/config-contract.test.ts
+++ b/packages/cli/src/utils/config-contract.test.ts
@@ -14,6 +14,7 @@ import {
   parseNumber,
   parsePositiveInteger,
   parsePositivePostgresInteger,
+  parsePostgresInteger,
   parseSafeInteger,
 } from "../commands/resources/param-types";
 import {
@@ -162,6 +163,14 @@ describe("config generation and sync", () => {
               price: 500,
               trialDays: 0,
               isDefault: true,
+              inheritsFromPriceId: null,
+            },
+            {
+              billingInterval: "monthly",
+              price: 999,
+              trialDays: 0,
+              isDefault: false,
+              inheritsFromPriceId: "price_123",
             },
           ],
           features: [],
@@ -194,6 +203,7 @@ describe("config generation and sync", () => {
               price: 499,
               trialDays: 0,
               isDefault: true,
+              inheritsFromPriceId: null,
             },
           ],
           features: [],
@@ -207,6 +217,32 @@ describe("config generation and sync", () => {
       action: "update",
       changes: ["price monthly trialDays: 0 → 14"],
     });
+  });
+
+  test("preserves optional existing plan settings when config omits them", () => {
+    const localConfig = config();
+    delete localConfig.plans.pro!.defaultInterval;
+    localConfig.plans.pro!.prices = [];
+    const remoteState: RemoteState = {
+      features: [],
+      plans: [
+        {
+          code: "pro",
+          name: "Pro",
+          description: null,
+          consumptionModel: null,
+          isFree: true,
+          isPublic: false,
+          sortOrder: 7,
+          prices: [],
+          features: [],
+        },
+      ],
+    };
+
+    expect(
+      computeDiff(localConfig, remoteState).plans.changes[0],
+    ).toMatchObject({ action: "unchanged" });
   });
 
   test("sends the complete versioned config", () => {
@@ -266,6 +302,8 @@ describe("resource number parsing", () => {
     expect(parseNonNegativeInteger("499")).toBe(499);
     expect(() => parseNonNegativePostgresInteger("2147483648")).toThrow();
     expect(() => parsePositivePostgresInteger("2147483648")).toThrow();
+    expect(parsePostgresInteger("-2147483648")).toBe(-2_147_483_648);
+    expect(() => parsePostgresInteger("-2147483649")).toThrow();
     expect(parseNonNegativePostgresInteger("2147483647")).toBe(2_147_483_647);
   });
 });

--- a/packages/cli/src/utils/config-loader.ts
+++ b/packages/cli/src/utils/config-loader.ts
@@ -1,6 +1,11 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { BillingConfig } from "@commet/node";
+import {
+  type BillingConfig,
+  type BillingConfigIssue,
+  getBillingConfigIssues,
+  parseBillingConfig,
+} from "@commet/node";
 import { createJiti } from "jiti";
 
 const CONFIG_NAMES = [
@@ -43,87 +48,26 @@ export async function loadBillingConfig(
     );
   }
 
-  const config = moduleRecord.default as BillingConfig;
+  const issues = getBillingConfigIssues(moduleRecord.default);
+  if (issues.length > 0) {
+    throw new BillingConfigValidationError(configPath, issues);
+  }
 
-  validateConfig(config, configPath);
+  const config = parseBillingConfig(moduleRecord.default);
 
   return { config, configPath };
 }
 
-const VALID_FEATURE_TYPES = new Set(["boolean", "usage", "seats"]);
-const VALID_INTERVALS = new Set([
-  "weekly",
-  "monthly",
-  "quarterly",
-  "yearly",
-  "one_time",
-]);
+export class BillingConfigValidationError extends Error {
+  readonly code = "config_invalid";
 
-function validateConfig(config: BillingConfig, configPath: string): void {
-  if (!config || typeof config !== "object") {
-    throw new Error(`${configPath}: config must be an object`);
-  }
-
-  if (!config.features || typeof config.features !== "object") {
-    throw new Error(`${configPath}: config.features must be an object`);
-  }
-
-  if (!config.plans || typeof config.plans !== "object") {
-    throw new Error(`${configPath}: config.plans must be an object`);
-  }
-
-  for (const [code, feature] of Object.entries(config.features)) {
-    if (!feature.name || typeof feature.name !== "string") {
-      throw new Error(`Feature "${code}": name is required`);
-    }
-    if (!VALID_FEATURE_TYPES.has(feature.type)) {
-      throw new Error(
-        `Feature "${code}": type must be one of: boolean, usage, seats`,
-      );
-    }
-  }
-
-  for (const [code, plan] of Object.entries(config.plans)) {
-    if (!plan.name || typeof plan.name !== "string") {
-      throw new Error(`Plan "${code}": name is required`);
-    }
-    if (!Array.isArray(plan.prices)) {
-      throw new Error(`Plan "${code}": prices must be an array`);
-    }
-
-    for (const price of plan.prices) {
-      if (!VALID_INTERVALS.has(price.interval)) {
-        throw new Error(
-          `Plan "${code}": price interval "${price.interval}" is not valid`,
-        );
-      }
-      if (typeof price.amount !== "number") {
-        throw new Error(`Plan "${code}": price amount must be a number`);
-      }
-    }
-
-    if (plan.prices.length > 0) {
-      if (!plan.defaultInterval) {
-        throw new Error(
-          `Plan "${code}": defaultInterval is required when prices are defined`,
-        );
-      }
-      const priceIntervals = new Set(plan.prices.map((p) => p.interval));
-      if (!priceIntervals.has(plan.defaultInterval)) {
-        throw new Error(
-          `Plan "${code}": defaultInterval "${plan.defaultInterval}" does not match any price interval (${[...priceIntervals].join(", ")})`,
-        );
-      }
-    }
-
-    if (plan.features) {
-      for (const featureCode of Object.keys(plan.features)) {
-        if (!config.features[featureCode]) {
-          throw new Error(
-            `Plan "${code}": references feature "${featureCode}" which is not defined in config.features`,
-          );
-        }
-      }
-    }
+  constructor(
+    readonly configPath: string,
+    readonly issues: BillingConfigIssue[],
+  ) {
+    super(
+      `${configPath}: ${issues.length} invalid config field${issues.length === 1 ? "" : "s"}`,
+    );
+    this.name = "BillingConfigValidationError";
   }
 }

--- a/packages/cli/src/utils/config-mapping.ts
+++ b/packages/cli/src/utils/config-mapping.ts
@@ -1,0 +1,102 @@
+import {
+  BILLING_CONFIG_SCHEMA_VERSION,
+  type BillingConfig,
+  type Feature,
+  type FeatureDef,
+  type Plan,
+  type PlanFeatureValue,
+} from "@commet/node";
+
+export function toFeatureDef(feature: Feature): FeatureDef {
+  if (feature.type === "boolean") {
+    return {
+      name: feature.name,
+      type: "boolean",
+      ...(feature.description ? { description: feature.description } : {}),
+    };
+  }
+
+  return {
+    name: feature.name,
+    type: feature.type,
+    ...(feature.unitName ? { unitName: feature.unitName } : {}),
+    ...(feature.description ? { description: feature.description } : {}),
+  };
+}
+
+export function toPlanFeatureValue(
+  planFeature: Plan["features"][number],
+): PlanFeatureValue {
+  const isSimpleBoolean =
+    planFeature.includedAmount == null &&
+    !planFeature.unlimited &&
+    !planFeature.overage?.enabled;
+
+  if (isSimpleBoolean) return planFeature.enabled;
+
+  return {
+    ...(planFeature.includedAmount != null
+      ? { included: planFeature.includedAmount }
+      : {}),
+    ...(planFeature.unlimited ? { unlimited: true } : {}),
+    ...(planFeature.overage?.enabled && planFeature.overage.unitPrice != null
+      ? { overage: { unitPrice: planFeature.overage.unitPrice } }
+      : {}),
+  };
+}
+
+export function remoteStateToBillingConfig(
+  features: Feature[],
+  plans: Plan[],
+): BillingConfig {
+  return {
+    schemaVersion: BILLING_CONFIG_SCHEMA_VERSION,
+    features: Object.fromEntries(
+      features.map((feature) => [feature.code, toFeatureDef(feature)]),
+    ),
+    plans: Object.fromEntries(
+      plans.map((remotePlan) => {
+        const basePrices = (remotePlan.prices ?? []).filter(
+          (price) => price.inheritsFromPriceId === null,
+        );
+        const defaultInterval =
+          basePrices.find((price) => price.isDefault)?.billingInterval ??
+          basePrices[0]?.billingInterval;
+
+        return [
+          remotePlan.code,
+          {
+            name: remotePlan.name,
+            ...(remotePlan.description
+              ? { description: remotePlan.description }
+              : {}),
+            ...(remotePlan.consumptionModel
+              ? { consumptionModel: remotePlan.consumptionModel }
+              : {}),
+            ...(defaultInterval ? { defaultInterval } : {}),
+            ...(remotePlan.isFree ? { isFree: true } : {}),
+            ...(remotePlan.isPublic === false ? { isPublic: false } : {}),
+            ...(remotePlan.sortOrder !== 0
+              ? { sortOrder: remotePlan.sortOrder }
+              : {}),
+            prices: basePrices.map((price) => ({
+              interval: price.billingInterval,
+              amountInCents: price.price,
+              ...(price.trialDays > 0 ? { trialDays: price.trialDays } : {}),
+            })),
+            ...(remotePlan.features.length > 0
+              ? {
+                  features: Object.fromEntries(
+                    remotePlan.features.map((planFeature) => [
+                      planFeature.code,
+                      toPlanFeatureValue(planFeature),
+                    ]),
+                  ),
+                }
+              : {}),
+          },
+        ];
+      }),
+    ),
+  };
+}

--- a/packages/cli/src/utils/diff.ts
+++ b/packages/cli/src/utils/diff.ts
@@ -4,14 +4,37 @@ import chalk from "chalk";
 type SdkPlanPrice = NonNullable<Plan["prices"]>[number];
 type SdkPlanFeature = NonNullable<Plan["features"]>[number];
 
-type RemoteFeature = Pick<Feature, "code" | "name" | "type" | "unitName">;
-type RemotePlanPrice = Pick<SdkPlanPrice, "billingInterval" | "price"> &
-  Partial<Pick<SdkPlanPrice, "isDefault">>;
-type RemotePlanFeature = Pick<SdkPlanFeature, "code">;
+type RemoteFeature = Pick<
+  Feature,
+  "code" | "name" | "type" | "unitName" | "description"
+>;
+type RemotePlanPrice = Pick<
+  SdkPlanPrice,
+  "billingInterval" | "price" | "isDefault" | "trialDays"
+>;
+interface RemotePlanFeature
+  extends Pick<
+    SdkPlanFeature,
+    "code" | "enabled" | "includedAmount" | "unlimited"
+  > {
+  overage: { enabled: boolean; unitPrice: number | null } | null;
+}
+
+function formatUsdCents(amountInCents: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(amountInCents / 100);
+}
 
 interface RemotePlan {
   code: string;
   name: string;
+  description: string | null;
+  consumptionModel: Plan["consumptionModel"];
+  isFree: boolean;
+  isPublic: boolean;
+  sortOrder: number;
   prices?: RemotePlanPrice[];
   features?: RemotePlanFeature[];
 }
@@ -69,12 +92,16 @@ export function computeDiff(
         `type: "${remoteFeature.type}" → "${localFeature.type}" (BLOCKED)`,
       );
     }
-    if (
-      "unitName" in localFeature &&
-      (remoteFeature.unitName ?? undefined) !== localFeature.unitName
-    ) {
+    const localUnitName =
+      "unitName" in localFeature ? (localFeature.unitName ?? null) : null;
+    if ((remoteFeature.unitName ?? null) !== localUnitName) {
       changes.push(
-        `unitName: "${remoteFeature.unitName ?? ""}" → "${localFeature.unitName}"`,
+        `unitName: "${remoteFeature.unitName ?? ""}" → "${localUnitName ?? ""}"`,
+      );
+    }
+    if ((remoteFeature.description ?? undefined) !== localFeature.description) {
+      changes.push(
+        `description: "${remoteFeature.description ?? ""}" → "${localFeature.description ?? ""}"`,
       );
     }
 
@@ -101,6 +128,31 @@ export function computeDiff(
     if (remotePlan.name !== localPlan.name) {
       changes.push(`name: "${remotePlan.name}" → "${localPlan.name}"`);
     }
+    if ((remotePlan.description ?? undefined) !== localPlan.description) {
+      changes.push(
+        `description: "${remotePlan.description ?? ""}" → "${localPlan.description ?? ""}"`,
+      );
+    }
+    if (remotePlan.consumptionModel !== (localPlan.consumptionModel ?? null)) {
+      changes.push(
+        `consumptionModel: "${remotePlan.consumptionModel ?? "none"}" → "${localPlan.consumptionModel ?? "none"}"`,
+      );
+    }
+    if (remotePlan.isFree !== (localPlan.isFree ?? false)) {
+      changes.push(
+        `isFree: ${remotePlan.isFree} → ${localPlan.isFree ?? false}`,
+      );
+    }
+    if (remotePlan.isPublic !== (localPlan.isPublic ?? true)) {
+      changes.push(
+        `isPublic: ${remotePlan.isPublic} → ${localPlan.isPublic ?? true}`,
+      );
+    }
+    if (remotePlan.sortOrder !== (localPlan.sortOrder ?? 0)) {
+      changes.push(
+        `sortOrder: ${remotePlan.sortOrder} → ${localPlan.sortOrder ?? 0}`,
+      );
+    }
 
     const remotePrices = remotePlan.prices ?? [];
     const remoteDefaultInterval =
@@ -123,11 +175,19 @@ export function computeDiff(
       const remotePrice = remotePriceMap.get(interval);
       if (!remotePrice) {
         changes.push(
-          `price ${interval}: new ($${(localPrice.amount / 10000).toFixed(2)})`,
+          `price ${interval}: new (${formatUsdCents(localPrice.amountInCents)})`,
         );
-      } else if (remotePrice.price !== localPrice.amount) {
+      } else if (remotePrice.price !== localPrice.amountInCents) {
         changes.push(
-          `price ${interval}: $${(remotePrice.price / 10000).toFixed(2)} → $${(localPrice.amount / 10000).toFixed(2)}`,
+          `price ${interval}: ${formatUsdCents(remotePrice.price)} → ${formatUsdCents(localPrice.amountInCents)}`,
+        );
+      }
+      if (
+        remotePrice &&
+        remotePrice.trialDays !== (localPrice.trialDays ?? 0)
+      ) {
+        changes.push(
+          `price ${interval} trialDays: ${remotePrice.trialDays} → ${localPrice.trialDays ?? 0}`,
         );
       }
     }
@@ -137,8 +197,42 @@ export function computeDiff(
         (remotePlan.features ?? []).map((f) => [f.code, f]),
       );
       for (const featureCode of Object.keys(localPlan.features)) {
-        if (!remotePlanFeatureMap.has(featureCode)) {
+        const remotePlanFeature = remotePlanFeatureMap.get(featureCode);
+        if (!remotePlanFeature) {
           changes.push(`feature ${featureCode}: new`);
+          continue;
+        }
+
+        const localFeatureValue = localPlan.features[featureCode];
+        if (localFeatureValue === undefined) continue;
+        const localFeatureState =
+          typeof localFeatureValue === "boolean"
+            ? {
+                enabled: localFeatureValue,
+                includedAmount: 0,
+                unlimited: false,
+                overageEnabled: false,
+                overageUnitPrice: 0,
+              }
+            : {
+                enabled: true,
+                includedAmount: localFeatureValue.included ?? 0,
+                unlimited: localFeatureValue.unlimited ?? false,
+                overageEnabled: localFeatureValue.overage !== undefined,
+                overageUnitPrice: localFeatureValue.overage?.unitPrice ?? 0,
+              };
+        const remoteFeatureState = {
+          enabled: remotePlanFeature.enabled,
+          includedAmount: remotePlanFeature.includedAmount ?? 0,
+          unlimited: remotePlanFeature.unlimited,
+          overageEnabled: remotePlanFeature.overage?.enabled ?? false,
+          overageUnitPrice: remotePlanFeature.overage?.unitPrice ?? 0,
+        };
+        if (
+          JSON.stringify(remoteFeatureState) !==
+          JSON.stringify(localFeatureState)
+        ) {
+          changes.push(`feature ${featureCode}: configuration changed`);
         }
       }
     }

--- a/packages/cli/src/utils/diff.ts
+++ b/packages/cli/src/utils/diff.ts
@@ -10,7 +10,11 @@ type RemoteFeature = Pick<
 >;
 type RemotePlanPrice = Pick<
   SdkPlanPrice,
-  "billingInterval" | "price" | "isDefault" | "trialDays"
+  | "billingInterval"
+  | "price"
+  | "isDefault"
+  | "trialDays"
+  | "inheritsFromPriceId"
 >;
 interface RemotePlanFeature
   extends Pick<
@@ -138,23 +142,30 @@ export function computeDiff(
         `consumptionModel: "${remotePlan.consumptionModel ?? "none"}" → "${localPlan.consumptionModel ?? "none"}"`,
       );
     }
-    if (remotePlan.isFree !== (localPlan.isFree ?? false)) {
-      changes.push(
-        `isFree: ${remotePlan.isFree} → ${localPlan.isFree ?? false}`,
-      );
+    if (
+      localPlan.isFree !== undefined &&
+      remotePlan.isFree !== localPlan.isFree
+    ) {
+      changes.push(`isFree: ${remotePlan.isFree} → ${localPlan.isFree}`);
     }
-    if (remotePlan.isPublic !== (localPlan.isPublic ?? true)) {
-      changes.push(
-        `isPublic: ${remotePlan.isPublic} → ${localPlan.isPublic ?? true}`,
-      );
+    if (
+      localPlan.isPublic !== undefined &&
+      remotePlan.isPublic !== localPlan.isPublic
+    ) {
+      changes.push(`isPublic: ${remotePlan.isPublic} → ${localPlan.isPublic}`);
     }
-    if (remotePlan.sortOrder !== (localPlan.sortOrder ?? 0)) {
+    if (
+      localPlan.sortOrder !== undefined &&
+      remotePlan.sortOrder !== localPlan.sortOrder
+    ) {
       changes.push(
-        `sortOrder: ${remotePlan.sortOrder} → ${localPlan.sortOrder ?? 0}`,
+        `sortOrder: ${remotePlan.sortOrder} → ${localPlan.sortOrder}`,
       );
     }
 
-    const remotePrices = remotePlan.prices ?? [];
+    const remotePrices = (remotePlan.prices ?? []).filter(
+      (price) => price.inheritsFromPriceId === null,
+    );
     const remoteDefaultInterval =
       remotePrices.find((p) => p.isDefault)?.billingInterval ?? null;
     if (

--- a/packages/cli/src/utils/generator.ts
+++ b/packages/cli/src/utils/generator.ts
@@ -1,48 +1,70 @@
-import type { Feature, Plan } from "@commet/node";
+import {
+  BILLING_CONFIG_SCHEMA_VERSION,
+  type Feature,
+  type Plan,
+} from "@commet/node";
+import { remoteStateToBillingConfig } from "./config-mapping";
+
+function quote(value: string): string {
+  return JSON.stringify(value);
+}
 
 export function generateConfigFile(features: Feature[], plans: Plan[]): string {
+  const config = remoteStateToBillingConfig(features, plans);
   const lines: string[] = [];
 
   lines.push('import { defineConfig } from "@commet/node";');
   lines.push("");
   lines.push("export default defineConfig({");
+  lines.push(`  schemaVersion: ${BILLING_CONFIG_SCHEMA_VERSION},`);
 
   lines.push("  features: {");
-  for (const f of features) {
-    const parts: string[] = [`name: "${f.name}"`, `type: "${f.type}"`];
-    if (f.unitName) parts.push(`unitName: "${f.unitName}"`);
-    if (f.description) parts.push(`description: "${f.description}"`);
-    lines.push(`    ${f.code}: { ${parts.join(", ")} },`);
+  for (const [code, configFeature] of Object.entries(config.features)) {
+    const parts: string[] = [
+      `name: ${quote(configFeature.name)}`,
+      `type: ${quote(configFeature.type)}`,
+    ];
+    if ("unitName" in configFeature && configFeature.unitName) {
+      parts.push(`unitName: ${quote(configFeature.unitName)}`);
+    }
+    if (configFeature.description) {
+      parts.push(`description: ${quote(configFeature.description)}`);
+    }
+    lines.push(`    ${quote(code)}: { ${parts.join(", ")} },`);
   }
   lines.push("  },");
 
   lines.push("  plans: {");
-  for (const p of plans) {
-    lines.push(`    ${p.code}: {`);
-    lines.push(`      name: "${p.name}",`);
-    if (p.description) lines.push(`      description: "${p.description}",`);
-    if (p.consumptionModel)
-      lines.push(`      consumptionModel: "${p.consumptionModel}",`);
-    if (p.isFree) lines.push("      isFree: true,");
-    if (p.isPublic === false) lines.push("      isPublic: false,");
-    if (p.sortOrder != null && p.sortOrder !== 0)
-      lines.push(`      sortOrder: ${p.sortOrder},`);
+  for (const [code, configPlan] of Object.entries(config.plans)) {
+    lines.push(`    ${quote(code)}: {`);
+    lines.push(`      name: ${quote(configPlan.name)},`);
+    if (configPlan.description) {
+      lines.push(`      description: ${quote(configPlan.description)},`);
+    }
+    if (configPlan.consumptionModel) {
+      lines.push(
+        `      consumptionModel: ${quote(configPlan.consumptionModel)},`,
+      );
+    }
+    if (configPlan.isFree) lines.push("      isFree: true,");
+    if (configPlan.isPublic === false) lines.push("      isPublic: false,");
+    if (configPlan.sortOrder !== undefined) {
+      lines.push(`      sortOrder: ${configPlan.sortOrder},`);
+    }
+    if (configPlan.defaultInterval) {
+      lines.push(
+        `      defaultInterval: ${quote(configPlan.defaultInterval)},`,
+      );
+    }
 
-    const prices = p.prices ?? [];
-    const defaultInterval =
-      prices.find((pr) => pr.isDefault)?.billingInterval ??
-      prices[0]?.billingInterval;
-    if (defaultInterval)
-      lines.push(`      defaultInterval: "${defaultInterval}",`);
-
-    if (prices.length === 0) {
+    if (configPlan.prices.length === 0) {
       lines.push("      prices: [],");
     } else {
       lines.push("      prices: [");
-      for (const price of prices) {
+      for (const price of configPlan.prices) {
         const priceParts = [
-          `interval: "${price.billingInterval}"`,
-          `amount: ${price.price}`,
+          `interval: ${quote(price.interval)}`,
+          `amountInCents: ${price.amountInCents}`,
         ];
         if (price.trialDays) priceParts.push(`trialDays: ${price.trialDays}`);
         lines.push(`        { ${priceParts.join(", ")} },`);
@@ -50,27 +72,30 @@ export function generateConfigFile(features: Feature[], plans: Plan[]): string {
       lines.push("      ],");
     }
 
-    const planFeatures = p.features ?? [];
-    if (planFeatures.length > 0) {
+    if (configPlan.features && Object.keys(configPlan.features).length > 0) {
       lines.push("      features: {");
-      for (const pf of planFeatures) {
-        const isSimpleBoolean =
-          pf.includedAmount == null && !pf.unlimited && !pf.overage?.enabled;
-
-        if (isSimpleBoolean) {
-          lines.push(`        ${pf.code}: ${pf.enabled},`);
+      for (const [featureCode, featureValue] of Object.entries(
+        configPlan.features,
+      )) {
+        if (typeof featureValue === "boolean") {
+          lines.push(`        ${quote(featureCode)}: ${featureValue},`);
         } else {
           const parts: string[] = [];
-          if (pf.includedAmount != null)
-            parts.push(`included: ${pf.includedAmount}`);
-          if (pf.unlimited) parts.push("unlimited: true");
-          if (pf.overage?.enabled && pf.overage.unitPrice != null) {
-            parts.push(`overage: { unitPrice: ${pf.overage.unitPrice} }`);
+          if (featureValue.included !== undefined) {
+            parts.push(`included: ${featureValue.included}`);
+          }
+          if (featureValue.unlimited) parts.push("unlimited: true");
+          if (featureValue.overage) {
+            parts.push(
+              `overage: { unitPrice: ${featureValue.overage.unitPrice} }`,
+            );
           }
           if (parts.length > 0) {
-            lines.push(`        ${pf.code}: { ${parts.join(", ")} },`);
+            lines.push(
+              `        ${quote(featureCode)}: { ${parts.join(", ")} },`,
+            );
           } else {
-            lines.push(`        ${pf.code}: {},`);
+            lines.push(`        ${quote(featureCode)}: {},`);
           }
         }
       }

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -23,6 +23,7 @@
     "lint:fix": "biome lint --write src/",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:unit": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "clean": "rm -rf .turbo node_modules dist"
@@ -38,6 +39,9 @@
   ],
   "author": "Commet Team",
   "license": "MIT",
+  "dependencies": {
+    "zod": "4.4.3"
+  },
   "devDependencies": {
     "@types/node": "24.13.1",
     "@vitest/coverage-v8": "4.1.8",

--- a/packages/node/src/__tests__/config.test.ts
+++ b/packages/node/src/__tests__/config.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from "vitest";
+import {
+  BILLING_CONFIG_JSON_SCHEMA,
+  BillingConfigSchema,
+  getBillingConfigIssues,
+} from "../index";
+import type { BillingConfig } from "../types/config";
+
+function validConfig(): BillingConfig {
+  return {
+    schemaVersion: 1,
+    features: {
+      api_calls: { name: "API calls", type: "usage" },
+    },
+    plans: {
+      pro: {
+        name: "Pro",
+        consumptionModel: "metered",
+        defaultInterval: "monthly",
+        sortOrder: 0,
+        prices: [{ interval: "monthly", amountInCents: 499, trialDays: 0 }],
+        features: {
+          api_calls: {
+            included: 100,
+            overage: { unitPrice: 10_000 },
+          },
+        },
+      },
+    },
+  };
+}
+
+describe("billing config contract", () => {
+  test("accepts USD 4.99 as 499 cents", () => {
+    expect(BillingConfigSchema.parse(validConfig())).toEqual(validConfig());
+  });
+
+  test("reports the breaking amount field migration", () => {
+    const input = {
+      schemaVersion: 1,
+      features: {},
+      plans: {
+        pro: {
+          name: "Pro",
+          prices: [{ interval: "monthly", amount: 4.99 }],
+        },
+      },
+    };
+
+    expect(getBillingConfigIssues(input)).toContainEqual({
+      code: "config_price_field_renamed",
+      path: "config.plans.pro.prices[0].amount",
+      expected: "Use amountInCents with an integer (499 = $4.99)",
+      received: 4.99,
+    });
+  });
+
+  test.each([
+    ["fraction", 4.99],
+    ["negative", -1],
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["unsafe integer", Number.MAX_SAFE_INTEGER + 1],
+  ])("rejects a %s minor-unit amount", (_name, amountInCents) => {
+    const input = structuredClone(validConfig());
+    input.plans.pro.prices[0]!.amountInCents = amountInCents;
+
+    expect(BillingConfigSchema.safeParse(input).success).toBe(false);
+  });
+
+  test("rejects trial days outside the PostgreSQL integer range", () => {
+    const input = structuredClone(validConfig());
+    input.plans.pro.prices[0]!.trialDays = 2_147_483_648;
+
+    expect(BillingConfigSchema.safeParse(input).success).toBe(false);
+  });
+
+  test.each([
+    -2_147_483_649, 2_147_483_648,
+  ])("rejects sort order %s outside the PostgreSQL integer range", (sortOrder) => {
+    const input = structuredClone(validConfig());
+    input.plans.pro.sortOrder = sortOrder;
+
+    expect(BillingConfigSchema.safeParse(input).success).toBe(false);
+  });
+
+  test.each([
+    {
+      features: { "API Calls": { name: "API calls", type: "usage" } },
+      plans: {},
+    },
+    {
+      features: {},
+      plans: {
+        "Pro Plan": {
+          name: "Pro",
+          prices: [],
+        },
+      },
+    },
+  ])("rejects non-canonical feature and plan codes", ({ features, plans }) => {
+    expect(
+      BillingConfigSchema.safeParse({
+        schemaVersion: 1,
+        features,
+        plans,
+      }).success,
+    ).toBe(false);
+  });
+
+  test.each([
+    {
+      name: "duplicate intervals",
+      mutate: (input: ReturnType<typeof validConfig>) => {
+        input.plans.pro.prices.push({
+          interval: "monthly",
+          amountInCents: 999,
+        });
+      },
+      code: "duplicate_price_interval",
+    },
+    {
+      name: "missing default interval price",
+      mutate: (input: ReturnType<typeof validConfig>) => {
+        input.plans.pro.defaultInterval = "yearly";
+      },
+      code: "default_interval_missing_price",
+    },
+    {
+      name: "free plan price",
+      mutate: (input: ReturnType<typeof validConfig>) => {
+        input.plans.pro.isFree = true;
+      },
+      code: "free_plan_prices_not_allowed",
+    },
+    {
+      name: "one-time trial",
+      mutate: (input: ReturnType<typeof validConfig>) => {
+        input.plans.pro.prices = [
+          { interval: "one_time", amountInCents: 499, trialDays: 7 },
+        ];
+        input.plans.pro.defaultInterval = "one_time";
+      },
+      code: "one_time_trial_not_allowed",
+    },
+    {
+      name: "missing feature reference",
+      mutate: (input: ReturnType<typeof validConfig>) => {
+        const planFeatures = input.plans.pro.features;
+        if (!planFeatures) throw new Error("Expected plan features fixture");
+        planFeatures.missing = true;
+      },
+      code: "feature_reference_missing",
+    },
+  ])("rejects $name", ({ mutate, code }) => {
+    const input = structuredClone(validConfig());
+    mutate(input);
+
+    expect(getBillingConfigIssues(input).map((issue) => issue.code)).toContain(
+      code,
+    );
+  });
+
+  test("publishes machine-readable schema metadata", () => {
+    const schema = JSON.stringify(BILLING_CONFIG_JSON_SCHEMA);
+    expect(schema).toContain("amountInCents");
+    expect(schema).toContain("schemaVersion");
+  });
+});

--- a/packages/node/src/__tests__/config.test.ts
+++ b/packages/node/src/__tests__/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
-  BILLING_CONFIG_JSON_SCHEMA,
+  BILLING_CONFIG_STRUCTURAL_JSON_SCHEMA,
   BillingConfigSchema,
   getBillingConfigIssues,
 } from "../index";
@@ -161,9 +161,10 @@ describe("billing config contract", () => {
     );
   });
 
-  test("publishes machine-readable schema metadata", () => {
-    const schema = JSON.stringify(BILLING_CONFIG_JSON_SCHEMA);
-    expect(schema).toContain("amountInCents");
-    expect(schema).toContain("schemaVersion");
+  test("publishes structural schema metadata for fields and scalar domains", () => {
+    const schema = JSON.stringify(BILLING_CONFIG_STRUCTURAL_JSON_SCHEMA);
+    expect(schema).toContain('"schemaVersion"');
+    expect(schema).toContain('"amountInCents":{"type":"integer"');
+    expect(schema).not.toContain('"amount":');
   });
 });

--- a/packages/node/src/__tests__/update-check.test.ts
+++ b/packages/node/src/__tests__/update-check.test.ts
@@ -32,6 +32,7 @@ describe("SDK update check", () => {
   });
 
   it("only enables checks during local development", () => {
+    vi.stubEnv("CI", "");
     vi.stubEnv("NODE_ENV", "development");
     expect(shouldCheckForSdkUpdates()).toBe(true);
 
@@ -95,6 +96,7 @@ describe("SDK update check", () => {
 
   it("schedules at most one registry request per process", async () => {
     vi.resetModules();
+    vi.stubEnv("CI", "");
     vi.stubEnv("NODE_ENV", "development");
     const fetchMock = vi.fn().mockResolvedValue(distTagsResponse("7.7.0"));
     vi.stubGlobal("fetch", fetchMock);

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -188,8 +188,8 @@ export type {
   PriceDef,
 } from "./types/config";
 export {
-  BILLING_CONFIG_JSON_SCHEMA,
   BILLING_CONFIG_SCHEMA_VERSION,
+  BILLING_CONFIG_STRUCTURAL_JSON_SCHEMA,
   BillingConfigSchema,
   defineConfig,
   FeatureDefSchema,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -177,6 +177,7 @@ export {
 } from "./types/common";
 export type {
   BillingConfig,
+  BillingConfigIssue,
   FeatureDef,
   InferFeatureCodes,
   InferPlanCodes,
@@ -186,7 +187,18 @@ export type {
   PlanFeatureValue,
   PriceDef,
 } from "./types/config";
-export { defineConfig } from "./types/config";
+export {
+  BILLING_CONFIG_JSON_SCHEMA,
+  BILLING_CONFIG_SCHEMA_VERSION,
+  BillingConfigSchema,
+  defineConfig,
+  FeatureDefSchema,
+  getBillingConfigIssues,
+  PlanDefSchema,
+  PlanFeatureValueSchema,
+  PriceDefSchema,
+  parseBillingConfig,
+} from "./types/config";
 export type {
   BillingInterval,
   ConsumptionModel,

--- a/packages/node/src/types/config.ts
+++ b/packages/node/src/types/config.ts
@@ -253,7 +253,8 @@ export const BillingConfigSchema = z
     }
   });
 
-export const BILLING_CONFIG_JSON_SCHEMA = z.toJSONSchema(BillingConfigSchema);
+export const BILLING_CONFIG_STRUCTURAL_JSON_SCHEMA =
+  z.toJSONSchema(BillingConfigSchema);
 
 export type FeatureDef = z.infer<typeof FeatureDefSchema>;
 export type PriceDef = z.infer<typeof PriceDefSchema>;

--- a/packages/node/src/types/config.ts
+++ b/packages/node/src/types/config.ts
@@ -1,48 +1,372 @@
-export type FeatureDef =
-  | { name: string; type: "boolean"; description?: string }
-  | {
-      name: string;
-      type: "usage";
-      unitName?: string;
-      description?: string;
+import { z } from "zod";
+
+export const BILLING_CONFIG_SCHEMA_VERSION = 1 as const;
+
+const configCodeSchema = z
+  .string()
+  .min(1)
+  .regex(
+    /^[a-z0-9_]+$/,
+    "Must contain lowercase letters, numbers, or underscores",
+  );
+
+const POSTGRES_INTEGER_MIN = -2_147_483_648;
+const POSTGRES_INTEGER_MAX = 2_147_483_647;
+
+const safeNonNegativeIntegerSchema = z
+  .number()
+  .int()
+  .nonnegative()
+  .refine(Number.isSafeInteger, "Must be a safe integer");
+
+const postgresNonNegativeIntegerSchema = z
+  .number()
+  .int()
+  .nonnegative()
+  .max(POSTGRES_INTEGER_MAX, "Must fit in a PostgreSQL integer");
+
+const postgresIntegerSchema = z
+  .number()
+  .int()
+  .min(POSTGRES_INTEGER_MIN, "Must fit in a PostgreSQL integer")
+  .max(POSTGRES_INTEGER_MAX, "Must fit in a PostgreSQL integer");
+
+const featureDescriptionSchema = {
+  name: z.string().min(1),
+  unitName: z.string().min(1).optional(),
+  description: z.string().optional(),
+};
+
+export const FeatureDefSchema = z.discriminatedUnion("type", [
+  z.strictObject({
+    name: featureDescriptionSchema.name,
+    type: z.literal("boolean"),
+    description: featureDescriptionSchema.description,
+  }),
+  z.strictObject({
+    ...featureDescriptionSchema,
+    type: z.literal("usage"),
+  }),
+  z.strictObject({
+    ...featureDescriptionSchema,
+    type: z.literal("seats"),
+  }),
+  z.strictObject({
+    ...featureDescriptionSchema,
+    type: z.literal("quota"),
+  }),
+]);
+
+export const PriceDefSchema = z.strictObject({
+  interval: z.enum(["weekly", "monthly", "quarterly", "yearly", "one_time"]),
+  amountInCents: safeNonNegativeIntegerSchema,
+  trialDays: postgresNonNegativeIntegerSchema.optional(),
+});
+
+const meteredPlanFeatureValueSchema = z.strictObject({
+  included: safeNonNegativeIntegerSchema.optional(),
+  unlimited: z.boolean().optional(),
+  overage: z
+    .strictObject({ unitPrice: safeNonNegativeIntegerSchema.positive() })
+    .optional(),
+});
+
+export const PlanFeatureValueSchema = z.union([
+  z.boolean(),
+  meteredPlanFeatureValueSchema,
+]);
+
+export const PlanDefSchema = z.strictObject({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  consumptionModel: z.enum(["metered", "credits", "balance"]).optional(),
+  defaultInterval: PriceDefSchema.shape.interval.optional(),
+  isFree: z.boolean().optional(),
+  isPublic: z.boolean().optional(),
+  sortOrder: postgresIntegerSchema.optional(),
+  prices: z.array(PriceDefSchema),
+  features: z.record(configCodeSchema, PlanFeatureValueSchema).optional(),
+});
+
+function addConfigIssue(
+  context: z.RefinementCtx,
+  path: PropertyKey[],
+  code: string,
+  expected: string,
+): void {
+  context.addIssue({
+    code: "custom",
+    path,
+    message: expected,
+    params: { configCode: code, expected },
+  });
+}
+
+export const BillingConfigSchema = z
+  .strictObject({
+    schemaVersion: z.literal(BILLING_CONFIG_SCHEMA_VERSION),
+    features: z.record(configCodeSchema, FeatureDefSchema),
+    plans: z.record(configCodeSchema, PlanDefSchema),
+  })
+  .superRefine((config, context) => {
+    const planNames = new Set<string>();
+    for (const [planCode, plan] of Object.entries(config.plans)) {
+      if (planNames.has(plan.name)) {
+        addConfigIssue(
+          context,
+          ["plans", planCode, "name"],
+          "duplicate_plan_name",
+          "Plan names must be unique",
+        );
+      }
+      planNames.add(plan.name);
+
+      const intervals = new Set<string>();
+      for (const [priceIndex, price] of plan.prices.entries()) {
+        if (intervals.has(price.interval)) {
+          addConfigIssue(
+            context,
+            ["plans", planCode, "prices", priceIndex, "interval"],
+            "duplicate_price_interval",
+            "Each billing interval can appear only once per plan",
+          );
+        }
+        intervals.add(price.interval);
+
+        if (price.interval === "one_time" && (price.trialDays ?? 0) > 0) {
+          addConfigIssue(
+            context,
+            ["plans", planCode, "prices", priceIndex, "trialDays"],
+            "one_time_trial_not_allowed",
+            "One-time prices cannot have trial days",
+          );
+        }
+      }
+
+      if (plan.isFree === true && plan.prices.length > 0) {
+        addConfigIssue(
+          context,
+          ["plans", planCode, "prices"],
+          "free_plan_prices_not_allowed",
+          "Free plans cannot define prices",
+        );
+      }
+
+      if (plan.prices.length > 0 && plan.defaultInterval === undefined) {
+        addConfigIssue(
+          context,
+          ["plans", planCode, "defaultInterval"],
+          "default_interval_required",
+          "A default interval is required when prices are defined",
+        );
+      }
+
+      if (
+        plan.defaultInterval !== undefined &&
+        !intervals.has(plan.defaultInterval)
+      ) {
+        addConfigIssue(
+          context,
+          ["plans", planCode, "defaultInterval"],
+          "default_interval_missing_price",
+          "The default interval must match one configured price",
+        );
+      }
+
+      for (const [featureCode, featureValue] of Object.entries(
+        plan.features ?? {},
+      )) {
+        const feature = config.features[featureCode];
+        if (!feature) {
+          addConfigIssue(
+            context,
+            ["plans", planCode, "features", featureCode],
+            "feature_reference_missing",
+            "The referenced feature must exist in config.features",
+          );
+          continue;
+        }
+
+        if (feature.type === "usage" && !plan.consumptionModel) {
+          addConfigIssue(
+            context,
+            ["plans", planCode, "consumptionModel"],
+            "usage_feature_requires_consumption_model",
+            "Plans with usage features must define a consumption model",
+          );
+        }
+
+        if (typeof featureValue === "boolean") continue;
+
+        if (feature.type === "boolean") {
+          addConfigIssue(
+            context,
+            ["plans", planCode, "features", featureCode],
+            "boolean_feature_value_invalid",
+            "Boolean features must use true or false",
+          );
+        }
+
+        if (featureValue.unlimited === true && featureValue.overage) {
+          addConfigIssue(
+            context,
+            ["plans", planCode, "features", featureCode, "overage"],
+            "unlimited_feature_overage_not_allowed",
+            "Unlimited features cannot define overage pricing",
+          );
+        }
+
+        if (
+          featureValue.unlimited === true &&
+          (featureValue.included ?? 0) > 0
+        ) {
+          addConfigIssue(
+            context,
+            ["plans", planCode, "features", featureCode, "included"],
+            "unlimited_feature_included_not_allowed",
+            "Unlimited features cannot define an included amount",
+          );
+        }
+
+        if (
+          featureValue.overage &&
+          plan.consumptionModel !== "metered" &&
+          plan.consumptionModel !== "balance"
+        ) {
+          addConfigIssue(
+            context,
+            ["plans", planCode, "features", featureCode, "overage"],
+            "overage_consumption_model_invalid",
+            "Overage pricing requires the metered or balance consumption model",
+          );
+        }
+
+        if (plan.isFree === true && featureValue.overage) {
+          addConfigIssue(
+            context,
+            ["plans", planCode, "features", featureCode, "overage"],
+            "free_plan_overage_not_allowed",
+            "Free plans cannot define overage pricing",
+          );
+        }
+      }
     }
-  | {
-      name: string;
-      type: "seats";
-      unitName?: string;
-      description?: string;
-    };
+  });
 
-export interface PriceDef {
-  interval: "weekly" | "monthly" | "quarterly" | "yearly" | "one_time";
-  /** Rate scale: 10000 = $1.00 */
-  amount: number;
-  trialDays?: number;
+export const BILLING_CONFIG_JSON_SCHEMA = z.toJSONSchema(BillingConfigSchema);
+
+export type FeatureDef = z.infer<typeof FeatureDefSchema>;
+export type PriceDef = z.infer<typeof PriceDefSchema>;
+export type PlanFeatureValue = z.infer<typeof PlanFeatureValueSchema>;
+export type PlanDef = z.infer<typeof PlanDefSchema>;
+export type BillingConfig = z.infer<typeof BillingConfigSchema>;
+
+export interface BillingConfigIssue {
+  code: string;
+  path: string;
+  expected: string;
+  received: unknown;
 }
 
-export type PlanFeatureValue =
-  | boolean
-  | {
-      included?: number;
-      unlimited?: boolean;
-      overage?: { unitPrice: number };
-    };
-
-export interface PlanDef {
-  name: string;
-  description?: string;
-  consumptionModel?: "metered" | "credits" | "balance";
-  defaultInterval?: PriceDef["interval"];
-  isFree?: boolean;
-  isPublic?: boolean;
-  sortOrder?: number;
-  prices: PriceDef[];
-  features?: Record<string, PlanFeatureValue>;
+function getPathValue(input: unknown, path: PropertyKey[]): unknown {
+  let current = input;
+  for (const segment of path) {
+    if (typeof current !== "object" || current === null) return undefined;
+    current = Reflect.get(current, segment);
+  }
+  return current;
 }
 
-export interface BillingConfig {
-  features: Record<string, FeatureDef>;
-  plans: Record<string, PlanDef>;
+function serializeReceivedValue(value: unknown): unknown {
+  if (value === undefined) return "<missing>";
+  if (typeof value === "number" && Number.isNaN(value)) return "NaN";
+  if (value === Number.POSITIVE_INFINITY) return "Infinity";
+  if (value === Number.NEGATIVE_INFINITY) return "-Infinity";
+  return value;
+}
+
+function getStringProperty(input: unknown, property: PropertyKey) {
+  if (typeof input !== "object" || input === null) return undefined;
+  const value = Reflect.get(input, property);
+  return typeof value === "string" ? value : undefined;
+}
+
+function formatConfigPath(path: PropertyKey[]): string {
+  return path.reduce<string>((formatted, segment) => {
+    if (typeof segment === "number") return `${formatted}[${segment}]`;
+    return `${formatted}.${String(segment)}`;
+  }, "config");
+}
+
+function expectedForZodIssue(issue: z.core.$ZodIssue): string {
+  if (issue.code === "invalid_type") return `Expected ${issue.expected}`;
+  if (issue.code === "invalid_value") return issue.message;
+  if (issue.code === "too_small") return issue.message;
+  if (issue.code === "too_big") return issue.message;
+  return issue.message;
+}
+
+export function getBillingConfigIssues(input: unknown): BillingConfigIssue[] {
+  const parsed = BillingConfigSchema.safeParse(input, { reportInput: true });
+  if (parsed.success) return [];
+
+  const legacyPricePaths = new Set(
+    parsed.error.issues
+      .filter(
+        (issue) =>
+          issue.code === "unrecognized_keys" && issue.keys.includes("amount"),
+      )
+      .map((issue) => issue.path.join(".")),
+  );
+
+  return parsed.error.issues.flatMap((issue): BillingConfigIssue[] => {
+    if (
+      issue.code === "invalid_type" &&
+      issue.path[issue.path.length - 1] === "amountInCents" &&
+      legacyPricePaths.has(issue.path.slice(0, -1).join("."))
+    ) {
+      return [];
+    }
+
+    if (issue.code === "unrecognized_keys") {
+      return issue.keys.map((key) => {
+        const path = [...issue.path, key];
+        const renamedPriceField = key === "amount";
+        return {
+          code: renamedPriceField
+            ? "config_price_field_renamed"
+            : "config_field_unknown",
+          path: formatConfigPath(path),
+          expected: renamedPriceField
+            ? "Use amountInCents with an integer (499 = $4.99)"
+            : "Remove the unknown field",
+          received: serializeReceivedValue(getPathValue(input, path)),
+        };
+      });
+    }
+
+    const configCode =
+      issue.code === "custom"
+        ? getStringProperty(issue.params, "configCode")
+        : undefined;
+    const customExpected =
+      issue.code === "custom"
+        ? getStringProperty(issue.params, "expected")
+        : undefined;
+
+    return [
+      {
+        code: configCode ?? `config_${issue.code}`,
+        path: formatConfigPath(issue.path),
+        expected: customExpected ?? expectedForZodIssue(issue),
+        received: serializeReceivedValue(getPathValue(input, issue.path)),
+      },
+    ];
+  });
+}
+
+export function parseBillingConfig(input: unknown): BillingConfig {
+  return BillingConfigSchema.parse(input);
 }
 
 export function defineConfig<const T extends BillingConfig>(config: T): T {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -869,6 +869,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      vitest:
+        specifier: 4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/coverage-v8@4.1.8)(msw@2.14.6(@types/node@24.13.1)(typescript@5.9.3))(vite@7.3.2(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.0)(yaml@2.8.3))
 
   packages/next:
     dependencies:
@@ -893,6 +896,10 @@ importers:
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/coverage-v8@4.1.8)(msw@2.14.6(@types/node@24.13.1)(typescript@5.9.3))(vite@7.3.2(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.0)(yaml@2.8.3))
 
   packages/node:
+    dependencies:
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: 24.13.1

--- a/turbo.json
+++ b/turbo.json
@@ -25,6 +25,9 @@
       "dependsOn": ["^build"]
     },
     "test": {},
+    "test:unit": {
+      "dependsOn": ["^build"]
+    },
     "clean": {
       "cache": false
     }


### PR DESCRIPTION
## Problem

The CLI config used an ambiguous amount field and separate pull, diff, push, and validation models, which allowed scale drift and unsafe numeric inputs.

## Result

- adds the canonical schema version 1 runtime contract and an explicitly structural JSON Schema
- represents base prices as integer amountInCents
- keeps pull, generated config, base-price diff, and push on one mapping
- preserves optional existing plan settings when config omits them
- validates CLI values against their actual safe-integer or PostgreSQL int4 domain
- prevents agent-mode pull from overwriting an invalid local config unless --yes is explicit
- documents a manual, reviewable migration instead of recommending pull --yes
- adds major changesets for Commet CLI 6 and @commet/node 10

## Compatibility

The intended breaking public surface is the config API: schemaVersion is required and amount becomes amountInCents. Capability metadata now distinguishes BillingConfigSchema from BILLING_CONFIG_STRUCTURAL_JSON_SCHEMA. Both packages carry major changesets. Normal SDK resources and public REST endpoints are unchanged.

Rollout order: deploy platform#1786 first, then publish these packages. Platform temporarily accepts integer CLI 5 configs, so existing automation keeps working during the rollout.

## Verification

- SDK unit tests: 141 passed, including under CI=true
- CLI contract tests: 12 passed
- package build: passed
- package typecheck and 22-resource registry validation: passed
- package lint: passed
- independent gpt-5.6-sol/high review: no blocking findings
- GitHub CI build, typecheck, unit tests, and lint: passed

Related to https://github.com/commet-labs/platform/issues/1762